### PR TITLE
got ssd.php working again.

### DIFF
--- a/pos/is4c-nf/scale-drivers/php-wrappers/ssd.php
+++ b/pos/is4c-nf/scale-drivers/php-wrappers/ssd.php
@@ -82,11 +82,11 @@ class ssd extends ScaleDriverWrapper {
 		global $CORE_LOCAL,$CORE_PATH;
 
 		$scale_data = file_get_contents($CORE_PATH.'scale-drivers/drivers/rs232/scale');
-		$fp = open($CORE_PATH.'scale-drivers/drivers/rs232/scale','w');
+		$fp = fopen($CORE_PATH.'scale-drivers/drivers/rs232/scale','w');
 		fclose($fp);
 
 		$scan_data = file_get_contents($CORE_PATH.'scale-drivers/drivers/rs232/scanner');
-		$fp = open($CORE_PATH.'scale-drivers/drivers/rs232/scanner','w');
+		$fp = fopen($CORE_PATH.'scale-drivers/drivers/rs232/scanner','w');
 		fclose($fp);
 	
 		$scale_display = '';


### PR DESCRIPTION
ssd.php had calls to nonexistent "open()" instead of fopen(), which completely disabled reading data from the ssd driver.
