### PR TITLE
FIX: different UPC validation

### DIFF
--- a/fannie/classlib2.0/data/controllers/CustdataController.php
+++ b/fannie/classlib2.0/data/controllers/CustdataController.php
@@ -108,6 +108,8 @@ class CustdataController {
 			case 'NumberOfChecks':
 			case 'memCoupons':	
 			case 'Shown':
+				if ($name === 0 || $name === True)
+					break; // switch does loose comparison...
 				$updateQ .= $name." = ?,";
 				$updateArgs[] = $value;
 				break;

--- a/fannie/classlib2.0/data/controllers/MeminfoController.php
+++ b/fannie/classlib2.0/data/controllers/MeminfoController.php
@@ -53,6 +53,8 @@ class MeminfoController {
 			case 'email_1':
 			case 'email_2':
 			case 'ads_OK':
+				if ($name === 0 || $name === True)
+					break; // switch does loose comparison...
 				$upQ .= $name." = ?,";
 				$args[] = $value;
 				break;

--- a/fannie/classlib2.0/data/controllers/ProdUpdateController.php
+++ b/fannie/classlib2.0/data/controllers/ProdUpdateController.php
@@ -31,7 +31,9 @@ class ProdUpdateController {
 	public static function add($upc,$fields){
 		global $FANNIE_OP_DB;
 		$dbc = FannieDB::get($FANNIE_OP_DB);
-		if (!is_numeric($upc) || $upc != ((int)$upc))
+		if (!is_numeric($upc))
+			return False;
+		if (!is_int($upc) && !ctype_digit($upc))
 			return False;
 		$upc = substr($upc,0,13);
 		$upc = str_pad($upc,13,'0',STR_PAD_LEFT);
@@ -46,6 +48,8 @@ class ProdUpdateController {
 			case 'tax':
 			case 'scale':
 			case 'inUse':
+				if ($name === 0 || $name === True)
+					break; // switch does loose comparison...
 				$q .= $name.',';
 				$args[] = $value;	
 				break;

--- a/fannie/classlib2.0/data/controllers/ProductsController.php
+++ b/fannie/classlib2.0/data/controllers/ProductsController.php
@@ -38,7 +38,9 @@ class ProductsController {
 	public static function update($upc,$fields, $update_only=False){
 		global $FANNIE_OP_DB;
 		$dbc = FannieDB::get($FANNIE_OP_DB);
-		if (!is_numeric($upc) || $upc != ((int)$upc))
+		if (!is_numeric($upc))
+			return False;
+		if (!is_int($upc) && !ctype_digit($upc))
 			return False;
 		$upc = substr($upc,0,13);
 		$upc = str_pad($upc,13,'0',STR_PAD_LEFT);
@@ -47,6 +49,8 @@ class ProductsController {
 		$chkR = $dbc->exec_statement($chkP, array($upc));
 		if ($dbc->num_rows($chkR) == 0)
 			return ($update_only===False ? self::add($upc,$fields) : True);
+
+		$valid_columns = $dbc->table_definition('products');
 
 		$updateQ = "UPDATE products SET ";
 		$updateArgs = array();
@@ -87,6 +91,8 @@ class ProductsController {
 			case 'store_id':
 				if ($name === 0 || $name === True)
 					break; // switch does loose comparison...
+				if (!isset($valid_columns[$name]))
+					break; // table does not have that column
 				$updateQ .= $name." = ?,";
 				$updateArgs[] = $value;
 				break;


### PR DESCRIPTION
Uses both is_int and ctype_digit. An actual integer or a string containing all digits are both valid but neither function handles both cases.
