### PR TITLE
BUGFIX: use correct relation for memType GROUP BY

### DIFF
--- a/fannie/cron/nightly.dtrans.php
+++ b/fannie/cron/nightly.dtrans.php
@@ -241,7 +241,7 @@ foreach($dates as $date) {
                 trans_type IN ('I','D')
                 AND upc <> 'RRR' AND card_no <> 0
                 AND ".$sql->datediff('tdate',"'$date'")."= 0
-                GROUP BY c.memType");
+                GROUP BY d.memType");
         }
         if ($sql->table_exists("sumTendersByDay") && strstr($FANNIE_SERVER_DBMS,"MYSQL")){	
             $sql->query("INSERT INTO sumTendersByDay
@@ -265,7 +265,7 @@ foreach($dates as $date) {
                 trans_type IN ('S') AND total <> 0
                 AND upc = 'DISCOUNT' AND card_no <> 0
                 AND ".$sql->datediff('tdate',"'$date'")."= 0
-                GROUP BY c.memType");
+                GROUP BY d.memType");
         }
     }
 } // for loop on dates in dtransactions


### PR DESCRIPTION
After this has been merged into master, it makes sense for all users to regenerate records in the tables $FANNIE_ARCHIVE_DB.sumDiscountsByDay and $FANNIE_ARCHIVE_DB.sumMemTypeSalesByDay with the now correct numbers.  Not sure how best to approach this, logistically; an update?  I can create it, if folks thinks that's the best approach.
