### PR TITLE
Database.php member_subtotal parameter test

### DIFF
--- a/pos/is4c-nf/lib/Database.php
+++ b/pos/is4c-nf/lib/Database.php
@@ -160,7 +160,7 @@ static public function getsubtotals()
     CoreLocal::set("memSpecial", (!$row || !isset($row['memSpecial'])) ? 0 : (double)$row["memSpecial"] );
     // staffSpecial => SUM(localtemptrans.total) where discounttype=4
     CoreLocal::set("staffSpecial", (!$row || !isset($row['staffSpecial'])) ? 0 : (double)$row["staffSpecial"] );
-    if ( CoreLocal::get("member_subtotal") !== False ) {
+    if ( CoreLocal::get("member_subtotal") != False ) {
         // percentDiscount => MAX(localtemptrans.percentDiscount)
         CoreLocal::set("percentDiscount", (!$row || !isset($row['percentDiscount'])) ? 0 : (double)$row["percentDiscount"] );
     }


### PR DESCRIPTION
CoreLocal::get("member_subtotal") should not test the data type. The actual value is 1/0, not true/false.
Related commit to PrehLib.php

Also, I think the --COMMENTS should be removed.  They aren't the way we do this. I used it when I was new here and wanted to make clear what I was changing.