### PR TITLE
Label change in ViewPurchaseOrders.php

### DIFF
--- a/fannie/purchasing/ViewPurchaseOrders.php
+++ b/fannie/purchasing/ViewPurchaseOrders.php
@@ -302,7 +302,7 @@ class ViewPurchaseOrders extends FannieRESTfulPage {
 
         $ret .= '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
         
-        $ret .= '<label>From</label> ';
+        $ret .= '<label>During</label> ';
         $ret .= '<select id="viewMonth" onchange="fetchOrders();" class="form-control">';
         $month = date('n');
         for($i=1; $i<= 12; $i++) {


### PR DESCRIPTION
Suggest changing label on month / year inputs from "From" to "During".
My brain looks at "From" associated with a date and thinks "date range" and looks for "To".
If that row of inputs is meant to be read as a sentence I think putting "Showing" first, before "Status", reads better:
Purchase Orders: Showing My Orders Status Placed During [From] April 2015
instead of the current
Purchase Orders: Status Placed Showing My Orders During [From] April 2015