### PR TITLE
PriceRounder change

### DIFF
--- a/fannie/classlib2.0/item/PriceRounder.php
+++ b/fannie/classlib2.0/item/PriceRounder.php
@@ -47,13 +47,17 @@ class PriceRounder
         // operate in cents
         $price = floor($price * 100);
 
-        while ($price % 10 != 5 && $price % 10 != 9) {
+        while ($price % 10 != 9) {
             $price++;
         }
 
         if ($price % 100 == 5 || $price % 100 == 9) {
             $price += 10;
         }
+		
+		if ($price % 100 <= 19) {
+			$price = $price - ($price % 100) - 1;
+		}
 
         return round($price/100.00, 2);
     }


### PR DESCRIPTION
as per request from Grocery dept, updated PriceRounder to round every
price change to end in a '9', as well as rounding down any price that
ends in change < 0.19 to 0.99.