### PR TITLE
BUGFIX: MemberREST autoComplete blocks reversed

### DIFF
--- a/fannie/classlib2.0/member/MemberREST.php
+++ b/fannie/classlib2.0/member/MemberREST.php
@@ -1148,17 +1148,17 @@ class MemberREST
     private static function autoCompleteFirstName($val)
     {
         if (\FannieConfig::config('CUST_SCHEMA') == 1) {
-            $query = 'SELECT FirstName
-            FROM custdata
-            WHERE FirstName LIKE ?
-            GROUP BY FirstName
-            ORDER BY FirstName';
-        } else {
             $query = 'SELECT firstName
             FROM Customers
             WHERE firstName LIKE ?
             GROUP BY firstName
             ORDER BY firstName';
+        } else {
+            $query = 'SELECT FirstName
+            FROM custdata
+            WHERE FirstName LIKE ?
+            GROUP BY FirstName
+            ORDER BY FirstName';
         }
 
         return array($query, array('%' . $val . '%'));
@@ -1167,17 +1167,17 @@ class MemberREST
     private static function autoCompleteLastName($val)
     {
         if (\FannieConfig::config('CUST_SCHEMA') == 1) {
-            $query = 'SELECT LastName
-            FROM custdata
-            WHERE LastName LIKE ?
-            GROUP BY LastName
-            ORDER BY LastName';
-        } else {
             $query = 'SELECT lastName
             FROM Customers
             WHERE lastName LIKE ?
             GROUP BY lastName
             ORDER BY lastName';
+        } else {
+            $query = 'SELECT LastName
+            FROM custdata
+            WHERE LastName LIKE ?
+            GROUP BY LastName
+            ORDER BY LastName';
         }
 
         return array($query, array('%' . $val . '%'));


### PR DESCRIPTION
The position of the $query blocks in FirstName and LastName below seem to be reversed.
The others in this set are like the third one in the original code below.

However, in my situation, with CUST_SCHEMA == 0 but with a few records the Customers table the FirstName autocomplete was returning names even with the blocks reversed, but the LastName was not. Now, with them in the right positions neither of them, nor address, nor city, nor email returns anything to the Member Search inputs. No errors in queries.log. JS console hard to interpret, "Empty string passed to getElementById()." in jquery seem to appear consistently when typing into either FirstName or LastName Member Search inputs. I'm looking for help on how to debug this.

In Firebug, the class "ui-autocomplete-loading" is added to the <input> when you start typing into it. And autocomplete="off", but I think it was even when the FirstName autocomplete was working.

// Reversed
    private static function autoCompleteFirstName($val)
    {
        if (\FannieConfig::config('CUST_SCHEMA') == 1) {
            $query = 'SELECT FirstName
            FROM custdata
            WHERE FirstName LIKE ?
            GROUP BY FirstName
            ORDER BY FirstName';
        } else {
            $query = 'SELECT firstName
            FROM Customers
            WHERE firstName LIKE ?
            GROUP BY firstName
            ORDER BY firstName';
        }

        return array($query, array('%' . $val . '%'));
    }

// Reversed
    private static function autoCompleteLastName($val)
    {
        if (\FannieConfig::config('CUST_SCHEMA') == 1) {
            $query = 'SELECT LastName
            FROM custdata
            WHERE LastName LIKE ?
            GROUP BY LastName
            ORDER BY LastName';
        } else {
            $query = 'SELECT lastName
            FROM Customers
            WHERE lastName LIKE ?
            GROUP BY lastName
            ORDER BY lastName';
        }

        return array($query, array('%' . $val . '%'));
    }

// Correct order
    private static function autoCompleteAddress($val)
    {
        if (\FannieConfig::config('CUST_SCHEMA') == 1) {
            $query = 'SELECT addressLineOne
                       FROM CustomerAccounts
                       WHERE addressLineOne LIKE ?
                       GROUP BY addressLineOne
                       ORDER BY addressLineOne';
        } else {
            $query = 'SELECT street
                       FROM meminfo
                       WHERE street LIKE ?
                       GROUP BY street
                       ORDER BY street';
        }

        return array($query, array('%' . $val . '%'));
    }