### PR TITLE
ProductList support multiDept without superdept

### DIFF
--- a/fannie/item/ProductListPage.php
+++ b/fannie/item/ProductListPage.php
@@ -591,6 +591,13 @@ class ProductListPage extends \COREPOS\Fannie\API\FannieReportTool
             }
             $inp = substr($inp, 0, strlen($inp)-1);
             $query .= ' AND i.upc IN (' . $inp . ') ';
+        } elseif (count($deptMulti) > 0) {
+                $query .= ' AND i.department IN (';
+                foreach ($deptMulti as $d) {
+                    $query .= '?,';
+                    $args[] = $d;
+                }
+                $query = substr($query, 0, strlen($query)-1) . ')';
         } else {
             $query .= ' AND i.department BETWEEN ? AND ? ';
             $args = array($deptStart, $deptEnd);
@@ -620,7 +627,9 @@ class ProductListPage extends \COREPOS\Fannie\API\FannieReportTool
         $prep = $dbc->prepare($query);
         $result = $dbc->execute($prep, $args);
 
-        if ($result === false || $dbc->numRows($result) == 0) {
+        if ($result === false) {
+            return 'Search failed. Please see the system administrator and/or the log.';
+        } elseif ($dbc->num_rows($result) == 0) {
             return 'No data found!';
         }
 


### PR DESCRIPTION
Currently the multiDept search returns nothing if a superdept isn't chosen because it get gets into a branch that assumes a range of depts (that branch does not require a superdept).  I don't think there's a need for the superdept if multiDept is preferred (The superdept selection makes the subdepts available, which the multiDept choice doesn't, but perhaps confusingly since it lists all the subdepts in the super, not just those for the chosen depts). The snippet at 594-600 is just a copy of the code from handling multiDept if there is a superdept.

I also suggest here (line 630) a distinction in handling between a failed search and one that returns nothing.  The failure notice would have helped me figure out the bug in subdept search that I reported earlier today.  Having a "Back" link in the message would be a nice touch.