### PR TITLE
offset & narrow tag update

### DIFF
--- a/fannie/admin/labels/pdf_layouts/WFC_Narrow.php
+++ b/fannie/admin/labels/pdf_layouts/WFC_Narrow.php
@@ -48,7 +48,36 @@ $r = 24; //y location of date for label
 $p = 6;  //x location fields on label
 $t = 28; //y location of SKU and vendor info
 $u = 24; //x locaiton of vendor info for label
+$w = 7; //x location of Brand info for label
+$x = 42; //y location of Brand info for label
 $down = 31.0;
+
+if($offset>0) {
+    
+    /* Need to set the beginnig y values so they 
+     * line up with the top of the page. 
+    $delta = -12
+    $n = $n+$delta; 
+    $j = $j+$delta;
+    $l = $l+$delta;
+    //$n = $n+$delta;
+    $r = $r+$delta;
+    $t = $t+$delta;
+    $x = $x+$delta
+    */
+
+    $m = $offset;
+    //increment counters
+    $i = $i + 52.7 * $offset;
+    $k = $k + 52.7 * $offset;
+    $m = $m + 1;
+    $p = $p + 52.7 * $offset;
+    $u = $u + 52.7 * $offset;
+    $w = $w + 52.7 * $offset;
+
+}
+
+
 
 //cycle through result array of query
 foreach($data as $row){
@@ -64,7 +93,9 @@ foreach($data as $row){
     $r = 24; //y location of date for label
     $p = 6;  //x location fields on label
     $t = 28; //y location of SKU and vendor info
-    $u = 24; //x locaiton of vendor info for label
+    $u = 24; //x location of vendor info for label
+    $w = 7; //x location of Brand info for label
+    $x = 42; //y location of Brand info for label
    }
 
    //If $i > 175, start a new line of labels
@@ -78,6 +109,8 @@ foreach($data as $row){
       $p = 6;
       $u = 24;
       $t = $t + $down;
+      $w = 7;
+      $x = $x + $down;
    }
    $price = $row['normal_price'];
    $desc = strtoupper(substr($row['description'],0,27));
@@ -89,6 +122,7 @@ foreach($data as $row){
    $check = $pdf->GetCheckDigit($upc);
    $tagdate = date('m/d/y');
    $vendor = substr($row['vendor'],0,7);
+   $brand = substr($row['brand'],0,27);
    
    //Start laying out a label 
    $pdf->SetFont('Arial','',8);  //Set the font 
@@ -99,17 +133,17 @@ foreach($data as $row){
    $curStr = "";
    $length = 0;
    $lines = 0;
-   foreach ($words as $w) {
-    if ($length + strlen($w) <= $limit) {
-        $curStr .= $w . ' ';
-        $length += strlen($w) + 1;
+   foreach ($words as $word) {
+    if ($length + strlen($word) <= $limit) {
+        $curStr .= $word . ' ';
+        $length += strlen($word) + 1;
     } else {
         $lines++;
         if ($lines >= 2) {
             break;
         }
-        $curStr = trim($curStr) . "\n" . $w . ' ';
-        $length = strlen($w)+1;
+        $curStr = trim($curStr) . "\n" . $word . ' ';
+        $length = strlen($word)+1;
     }
    }
    $pdf->SetXY($p, $n-3);
@@ -117,23 +151,27 @@ foreach($data as $row){
    
    //$pdf->TEXT($p,$n,$desc);   //Add description to label
 
-   $pdf->TEXT($p,$r,$tagdate);  //Add date to lable
+   $pdf->TEXT($p,$r,$tagdate);  //Add date to label
    $pdf->TEXT($p+12,$r,$size);  //Add size to label
+   $pdf->TEXT($w,$x,$brand);  //add brand
    $pdf->SetFont('Arial','B',18); //change font for price
    $pdf->TEXT($k,$l,$price);  //add price
 
+
    $newUPC = $upc . $check; //add check digit to upc
    if (strlen($upc) <= 11)
-    $pdf->UPC_A($i,$j,$upc,7,.25);  //generate barcode and place on label
+    $pdf->UPC_A($i,$j,$upc,4,.25);  //generate barcode and place on label
    else
-    $pdf->EAN13($i,$j,$upc,7,.25);  //generate barcode and place on label
+    $pdf->EAN13($i,$j,$upc,4,.25);  //generate barcode and place on label
+   
 
-   //increment counters    
-   $i =$i+ 52.7;
+   //increment counters
+   $i = $i + 52.7;
    $k = $k + 52.7;
    $m = $m + 1;
    $p = $p + 52.7;
    $u = $u + 52.7;
+   $w = $w + 52.7;
 }
 
 $pdf->Output();  //Output PDF file to screen.

--- a/fannie/admin/labels/pdf_layouts/WFC_New.php
+++ b/fannie/admin/labels/pdf_layouts/WFC_New.php
@@ -52,6 +52,11 @@ $height = 31; // tag height in mm
 $left = 5; // left margin
 $top = 15; // top margin
 
+// undo margin if offset is true
+if($offset) {
+    $top = 0;
+}
+
 $pdf->SetTopMargin($top);  //Set top margin of the page
 $pdf->SetLeftMargin($left);  //Set left margin of the page
 $pdf->SetRightMargin($left);  //Set the right margin of the page
@@ -62,6 +67,24 @@ $num = 1; // count tags
 $x = $left;
 $y = $top;
 //cycle through result array of query
+for ($ocount=0;$ocount<$offset;$ocount++){
+    // move right by tag width
+    $x += $width;
+
+    if ($num % 32 == 0){
+        $pdf->AddPage();
+        $x = $left;
+        $y = $top;
+    }
+    else if ($num % 4 == 0){
+        $x = $left;
+        $y += $height;
+    }
+
+    $num++;
+}
+
+
 foreach($data as $row){
 
     if (strlen(ltrim($row['upc'], '0')) <= 4) continue;


### PR DESCRIPTION
**WFC_New** 
- updated offset chunk to adjust for the missing half-sized top row of shelf tag sheets

**WFC_Narrow** 
- reduced size of bar code
- added brand info on a new line
- added offset functionality (x position of tags works, y position doesn't work with sheets missing the top row. Narrow tags is set up much differently than New tags. I'm not sure if there is a way to get the y values to line up with the top of the page, or if we should just create a Narrow_New class).
