### PR TITLE
Enable case-size input on vendor selection

### DIFF
--- a/fannie/item/modules/BaseItemModule.php
+++ b/fannie/item/modules/BaseItemModule.php
@@ -845,10 +845,10 @@ HTML;
             }).done(function(resp) {
                 if (!resp.error) {
                     $('#local-origin-id').val(resp.localID);
-                    $('.product-case-size').prop('disabled', false);
+                    $('#product-case-size').prop('disabled', false);
                     $('#product-sku-field').prop('disabled', false);
                 } else {
-                    $('.product-case-size').prop('disabled', true);
+                    $('#product-case-size').prop('disabled', true);
                     $('#product-sku-field').prop('disabled', true);
                 }
             });


### PR DESCRIPTION
In BaseItemModule when, for a new item without a vendor a vendor is selected the initially disabled sku is enabled but case-size isn't. Changing the "." reference on product-case-size to a "#" reference fixes this.