### PR TITLE
more issues with using offset fixed (worked around)

### DIFF
--- a/fannie/admin/labels/pdf_layouts/WFC_New.php
+++ b/fannie/admin/labels/pdf_layouts/WFC_New.php
@@ -54,7 +54,7 @@ $top = 15; // top margin
 
 // undo margin if offset is true
 if($offset) {
-    $top = 0;
+    $top = 32;
 }
 
 $pdf->SetTopMargin($top);  //Set top margin of the page


### PR DESCRIPTION
It turns out that WFC_New tags was having the same issue printing to the top of a page with a zero margin as WFC_Narrow.
**WFC_New** now skips the first row when printing using offset. 