### PR TITLE
Item Editor subdepts default

### DIFF
--- a/fannie/item/modules/BaseItemModule.php
+++ b/fannie/item/modules/BaseItemModule.php
@@ -606,7 +606,9 @@ HTML;
             $jsVendorID = $rowItem['default_vendor_id'] > 0 ? $rowItem['default_vendor_id'] : 'no-vendor';
             $ret .= '<select name="subdept[]" id="subdept{{store_id}}" 
                 class="form-control chosen-select syncable-input">';
-            $ret .= isset($subs[$rowItem['department']]) ? $subs[$rowItem['department']] : '<option value="0">None</option>';
+            $ret .= sprintf('<option %s value="0">None</option>',
+                ($rowItem['subdept'] == 0 ? 'selected':''));
+            $ret .= isset($subs[$rowItem['department']]) ? $subs[$rowItem['department']] : '';
             $ret .= '</select>';
             $ret .= '</td>
                 <th class="small text-right">SKU</th>


### PR DESCRIPTION
Currently if a department has subdepts and `products.subdept = 0` the editor does not offer the 0=None option and assigns the alphabetically first subdept on Update.  The proposed change supports the 0=None option, including `SELECTED` if it is the current value.  The chained selectors in the page still work as they did before after this change.

On a related issue, the behaviour I would like when the department is changed and then changed back to the original value is for the original subdept to also be restored.  Currently the current subdept is lost if dept is changed.  I don't know how this might be done.