### PR TITLE
Co+ price file format changed for May 2016 and default column

### DIFF
--- a/fannie/batches/CAP/CoopDealsUploadPage.php
+++ b/fannie/batches/CAP/CoopDealsUploadPage.php
@@ -38,26 +38,26 @@ class CoopDealsUploadPage extends \COREPOS\Fannie\API\FannieUploadPage
     protected $preview_opts = array(
         'upc' => array(
             'display_name' => 'UPC',
-            'default' => 7,
+            'default' => 8,
             'required' => true
         ),
         'price' => array(
             'display_name' => 'Sale Price',
-            'default' => 24,
+            'default' => 26,
             'required' => true
         ),
         'abt' => array(
             'display_name' => 'A/B/TPR',
-            'default' => 5,
+            'default' => 6,
             'required' => true
         ),
         'sku' => array(
             'display_name' => 'SKU',
-            'default' => 8,
+            'default' => 9,
         ),
         'mult' => array(
             'display_name' => 'Line Notes',
-            'default' => 13,
+            'default' => 15,
         ),
     );
 


### PR DESCRIPTION
selections need to be adjusted. You can still use the tool w/o
this fix but you have to manually correct the column selections.