### PR TITLE
New scale driver command "wakeup".

### DIFF
--- a/pos/is4c-nf/parser-class-lib/parse/Wakeup.php
+++ b/pos/is4c-nf/parser-class-lib/parse/Wakeup.php
@@ -32,7 +32,7 @@ class Wakeup extends Parser {
 
     function parse($str){
         $ret = $this->default_json();
-        $ret['udpmsg'] = $str == 'WAKEUP' ? 'rePoll' : 'reBoot';
+        $ret['udpmsg'] = $str == 'WAKEUP' ? 'wakeup' : 'reBoot';
         return $ret;
     }
 

--- a/pos/is4c-nf/scale-drivers/drivers/NewMagellan/SPH_Magellan_Scale.cs
+++ b/pos/is4c-nf/scale-drivers/drivers/NewMagellan/SPH_Magellan_Scale.cs
@@ -91,15 +91,16 @@ public class SPH_Magellan_Scale : SerialPortHandler
             scale_state = WeighState.None;
             GetStatus();
             */
+        } else if (msg == "wakeup") {
+            scale_state = WeighState.None;
+            GetStatus();
         } else if (msg == "reBoot") {
             scale_state = WeighState.None;
-            /*
             lock (writeLock) {
                 sp.Write("S10\r");
-                Thread.Sleep(1500);
+                Thread.Sleep(5000);
                 sp.Write("S14\r");
             }
-            */
         }
     }
 

--- a/pos/is4c-nf/scale-drivers/php-wrappers/NewMagellan.php
+++ b/pos/is4c-nf/scale-drivers/php-wrappers/NewMagellan.php
@@ -96,6 +96,9 @@ class NewMagellan extends ScaleDriverWrapper {
         case 'reboot':
             UdpComm::udpSend('reBoot');
             break;
+        case 'wakeup':
+            UdpComm::udpSend('wakeup');
+            break;
         }
     }
 }


### PR DESCRIPTION
This is identical to the old "rePoll". Periodic requests to the
scale for this behavior (S14) should NOT be necessary and seem
to cause problems. The "wakeup" alias is only sent by the
WAKEUP command which should guarantee it only occurs when
the cashier manually intervenes