### PR TITLE
Subdept clause wrecks the query. A more robust fix will go into

### DIFF
--- a/fannie/reports/PluSkuReport/PluSkuReport.php
+++ b/fannie/reports/PluSkuReport/PluSkuReport.php
@@ -93,7 +93,7 @@ class PluSkuReport extends FannieReportPage
                 $query .= '?,';
                 $args[] = $d;
             }
-            $query = substr($query, 0, strlen($query-1)) . ') ';
+            $query = .= substr($query, 0, strlen($query-1)) . ') ';
         }
         $prep = $dbc->prepare($query);
         $res = $dbc->execute($prep, $args);


### PR DESCRIPTION
upstream later but the one-liner should be easier to merge
backwards into earlier verisons