### PR TITLE
Add column PurchaseOrderItems.isSpecialOrder

### DIFF
--- a/common/BasicModel.php
+++ b/common/BasicModel.php
@@ -1205,6 +1205,22 @@ class $name extends " . $this->new_model_namespace . ($as_view ? 'ViewModel' : '
         return json_encode($this->instance);
     }
 
+    public function toStdClass()
+    {
+        $ret = new \stdClass();
+        foreach ($this->columns as $name => $info) {
+            $val = null;
+            if (isset($this->instance[$name])) {
+                $val = $this->instance[$name];
+            } elseif (isset($this->instance['default'])) {
+                $val = $this->instance['default'];
+            }
+            $ret->{$name} = $val;
+        }
+
+        return $ret;
+    }
+
     /**
       Return an HTML string with <option> tags for
       each record. Table must have a single column 

--- a/fannie/classlib2.0/data/models/op/InventoryCacheModel.php
+++ b/fannie/classlib2.0/data/models/op/InventoryCacheModel.php
@@ -62,6 +62,7 @@ class InventoryCacheModel extends BasicModel
                 WHERE internalUPC=?
                     AND placedDate IS NOT NULL
                     AND storeID=?
+                    AND i.isSpecialOrder = 0
                     AND (placedDate >= ? OR receivedDate >= ?)');
         }
 

--- a/fannie/classlib2.0/data/models/op/PurchaseOrderItemsModel.php
+++ b/fannie/classlib2.0/data/models/op/PurchaseOrderItemsModel.php
@@ -43,6 +43,7 @@ class PurchaseOrderItemsModel extends BasicModel
     'description' => array('type'=>'VARCHAR(50)'),
     'internalUPC' => array('type'=>'VARCHAR(13)'),
     'salesCode' => array('type'=>'INT'),
+    'isSpecialOrder' => array('type'=>'TINYINT', 'default'=>0),
     );
 
     protected $preferred_db = 'op';

--- a/fannie/purchasing/js/view.js
+++ b/fannie/purchasing/js/view.js
@@ -107,3 +107,10 @@ function autoSaveNotes(oid, elem) {
     }, 2000);
 }
 
+function isSO(oid, sku, isSO) {
+    $.ajax({
+        type: 'post',
+        data: 'id='+oid+'&sku='+sku+'&isSO='+isSO
+    });
+}
+


### PR DESCRIPTION
Including special orders special orders in purchase orders and marking them as such to be excluded in inventory counting seems more natural than trying to manage them in narrow windows between POS exports and placing orders.