### PR TITLE
Add Begin Date to House Coupon list

### DIFF
--- a/fannie/modules/plugins2.0/HouseCoupon/HouseCouponEditor.php
+++ b/fannie/modules/plugins2.0/HouseCoupon/HouseCouponEditor.php
@@ -233,9 +233,14 @@ class HouseCouponEditor extends FanniePage
         $ret .= '</p>';
         $ret .= '</form>';
         $ret .= '<table class="table">';
-        $ret .= '<tr><th>ID</th><th>Name</th><th>Value</th><th>Expires</th></tr>';
+        $ret .= '<tr><th>ID</th><th>Name</th><th>Value</th>';
+        $ret .= '<th>Begins</th><th>Expires</th></tr>';
         $model = new HouseCouponsModel($dbc);
         foreach($model->find('coupID') as $obj) {
+            if (strstr($obj->startDate(), ' ')) {
+                $tmp = explode(' ', $obj->startDate());
+                $obj->startDate($tmp[0]);
+            }
             if (strstr($obj->endDate(), ' ')) {
                 $tmp = explode(' ', $obj->endDate());
                 $obj->endDate($tmp[0]);
@@ -252,7 +257,7 @@ class HouseCouponEditor extends FanniePage
                 $report_dates = array(date('Y-m-01'), date('Y-m-t'));
             }
             $ret .= sprintf('<tr><td>#%d <a href="HouseCouponEditor.php?edit_id=%d">Edit</a></td>
-                    <td>%s</td><td>%.2f%s</td><td>%s</td>
+                    <td>%s</td><td>%.2f%s</td><td>%s</td><td>%s</td>
                     <td>
                         <a href="%sws/barcode-pdf/?upc=%s&name=%s"
                         class="btn btn-default">Print Barcode</a>
@@ -262,7 +267,8 @@ class HouseCouponEditor extends FanniePage
                         class="btn btn-default %s">Member Baskets</a>
                     </tr>',
                     $obj->coupID(),$obj->coupID(),$obj->description(),
-                    $obj->discountValue(), $obj->discountType(), $obj->endDate(),
+                    $obj->discountValue(), $obj->discountType(),
+                    $obj->startDate(), $obj->endDate(),
                     $FANNIE_URL,
                     ('499999' . str_pad($obj->coupID(), 5, '0', STR_PAD_LEFT)),
                     urlencode($obj->description()),


### PR DESCRIPTION
Editing startDate is already supported, it just hasn't been accommodated in the list of coupons.

I've also noticed that this doesn't handle, i.e. doesn't return "this month" if:
+ startDate of NULL or 1969-12-31
+ endDate of 2044 or later. (2035 is ok, I didn't try years 2036 - 2044). endDate is 1969-12-31.
            /**
              If coupon period is more than 45 days, use the current month
              as a reporting period
            */
            if (strtotime($report_dates[1]) - strtotime($report_dates[0]) > (86400 * 45)) {
                $report_dates = array(date('Y-m-01'), date('Y-m-t'));
            }