### PR TITLE
Customer display fixes

### DIFF
--- a/pos/is4c-nf/gui-modules/posCustDisplay.php
+++ b/pos/is4c-nf/gui-modules/posCustDisplay.php
@@ -20,13 +20,14 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 *********************************************************************************/
- 
+
 use COREPOS\pos\lib\gui\BasicCorePage;
 use COREPOS\pos\lib\DisplayLib;
 include_once(dirname(__FILE__).'/../lib/AutoLoader.php');
 
-class posCustDisplay extends BasicCorePage 
+class posCustDisplay extends BasicCorePage
 {
+    protected $title = "COREPOS Customer Display";
 
     public function body_content()
     {
@@ -40,7 +41,7 @@ class posCustDisplay extends BasicCorePage
             echo "<div class=\"centerOffset\">";
             echo DisplayLib::plainmsg(CoreLocal::get("plainmsg"));
             echo "</div>";
-        } else {    
+        } else {
             // No input and no messages, so
             // list the items
             if (CoreLocal::get("End") == 1) {
@@ -75,4 +76,3 @@ class posCustDisplay extends BasicCorePage
 }
 
 AutoLoader::dispatch();
-

--- a/pos/is4c-nf/js/CustomerDisplay.js
+++ b/pos/is4c-nf/js/CustomerDisplay.js
@@ -22,9 +22,9 @@ function updateCustomerDisplay(identifier, content)
 
 function reloadCustomerDisplay()
 {
-    if (!$.isWindow(customerWindow)) {
+    if ((!$.isWindow(customerWindow))) {
         launchCustomerDisplay();
+    } else {
+        customerWindow.location.reload();
     }
-    customerWindow.location.reload();
 }
-

--- a/pos/is4c-nf/js/CustomerDisplay.js
+++ b/pos/is4c-nf/js/CustomerDisplay.js
@@ -22,7 +22,7 @@ function updateCustomerDisplay(identifier, content)
 
 function reloadCustomerDisplay()
 {
-    if ((!$.isWindow(customerWindow))) {
+    if (!$.isWindow(customerWindow)) {
         launchCustomerDisplay();
     } else {
         customerWindow.location.reload();

--- a/pos/is4c-nf/lib/gui/BasicCorePage.php
+++ b/pos/is4c-nf/lib/gui/BasicCorePage.php
@@ -28,16 +28,16 @@ use COREPOS\pos\lib\UdpComm;
 use COREPOS\pos\lib\DriverWrappers\ScaleDriverWrapper;
 use \CoreLocal;
 
-/** 
+/**
 
  @class BasicCorePage
-  
+
    This is the base class for all display scripts
 
    Display scripts are not required to use this
    base class but it does provide a lot of common
    functionality for building HTML pages with standard
-   headers, footers, and styling. 
+   headers, footers, and styling.
 
  */
 
@@ -49,6 +49,7 @@ class BasicCorePage extends \COREPOS\common\ui\CorePage
     */
     protected $page_url;
     protected $body_class='mainBGimage';
+    protected $title = "COREPOS";
 
     /**
       Constructor
@@ -91,7 +92,7 @@ class BasicCorePage extends \COREPOS\common\ui\CorePage
         <html>
         <?php
         echo "<head>";
-        echo "<title>COREPOS</title>";
+        echo "<title>".$this->title."</title>";
         $charset = CoreLocal::get('CoreCharSet') === '' ? 'utf-8' : CoreLocal::get('CoreCharSet');
         // 18Aug12 EL Add content/charset.
         echo "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=$charset\" />\n";
@@ -198,7 +199,7 @@ JAVASCRIPT;
     {
         $my_url = $this->page_url;
         $this->add_onload_command("betterDate();\n\$('#reginput').focus();");
-        
+
         // this needs to be configurable; just fixing
         // a giant PHP warning for the moment
         $time = strftime("%m/%d/%y %I:%M %p", time());
@@ -274,11 +275,11 @@ JAVASCRIPT;
     {
         ?>
         <div id="scalebox">
-            <div id="scaleTop" class="coloredArea"> 
+            <div id="scaleTop" class="coloredArea">
             <?php echo _("weight"); ?>
             </div>
             <div id="scaleBottom">
-            <?php echo DisplayLib::scaledisplaymsg(); ?>    
+            <?php echo DisplayLib::scaledisplaymsg(); ?>
             </div>
             <div id="scaleIconBox">
             <?php echo DisplayLib::drawNotifications(); ?>
@@ -384,7 +385,7 @@ JAVASCRIPT;
       This one ignores scan input and runs anything
       else through the parser
     */
-    protected function noscan_parsewrapper_js() 
+    protected function noscan_parsewrapper_js()
     {
     ?>
     <script type="text/javascript" src="<?php echo $this->page_url; ?>js/ajax-parser.js"></script>
@@ -408,7 +409,7 @@ JAVASCRIPT;
   scripts. If the URL in the browser address bar
   is your script, it's a top level script. No other
   includes are necessary. AutoLoader will include
-  other classes as needed. 
+  other classes as needed.
 
   body_content() draws the page. Methods from BasicCorePage
   provide the standard input box at the top and footer
@@ -423,4 +424,3 @@ JAVASCRIPT;
   necessary to actually display anything.
 
 */
-


### PR DESCRIPTION
This makes two changes, and I'd be happy to split them up into separate pull requests if you'd prefer, but it's small enough that I didn't feel the need to.

First, I set the `<title>` tag of the customer window to "COREPOS Customer Display". This required a small modification to `BasicCorePage` to allow subclasses to change the title.

Second, I cleaned up the logic in the `reloadCustomerDisplay()` javascript function. It was launching the customer display window and promptly reloading it, before it could fully load. This caused Firefox to reload `about:blank` and forget about the original URL it was trying to load.