### PR TITLE
Agressively re-focus on #reginput

### DIFF
--- a/pos/is4c-nf/lib/gui/BasicCorePage.php
+++ b/pos/is4c-nf/lib/gui/BasicCorePage.php
@@ -201,6 +201,7 @@ JAVASCRIPT;
     {
         $my_url = $this->page_url;
         $this->add_onload_command("betterDate();\n\$('#reginput').focus();");
+        $this->add_onload_command("setInterval(function(){\$('#reginput').focus();}, 500);\n");
 
         // this needs to be configurable; just fixing
         // a giant PHP warning for the moment


### PR DESCRIPTION
We were having some issues where the reginput box was getting defocused. This change just makes sure that doesn't happen. From everything I've seen so far this shouldn't break anything, but i'm not 100% sure and would like feedback.