### PR TITLE
BUGFIX: backend interface doesn't setup QttyEnforcedPM correctly

### DIFF
--- a/fannie/classlib2.0/data/models/op/BatchesModel.php
+++ b/fannie/classlib2.0/data/models/op/BatchesModel.php
@@ -87,9 +87,9 @@ those same items revert to normal pricing.
                     INNER JOIN batchList AS l ON p.upc=l.upc
                     INNER JOIN batches AS b ON l.batchID=b.batchID
                     " . ($isHQ ? ' INNER JOIN StoreBatchMap AS m ON b.batchID=m.batchID and p.store_id=m.storeID ' : '') . "
-                SET p.start_date = b.startDate, 
+                SET p.start_date = b.startDate,
                     p.end_date=b.endDate,
-                    p.special_price=l.salePrice,
+                    p.special_price=CASE WHEN l.pricemethod=2 THEN p.normal_price ELSE l.salePrice END,
                     p.specialgroupprice=CASE WHEN l.salePrice < 0 THEN -1*l.salePrice ELSE l.salePrice END,
                     p.specialpricemethod=l.pricemethod,
                     p.specialquantity=l.quantity,
@@ -111,9 +111,9 @@ those same items revert to normal pricing.
                     INNER JOIN batchList as l ON l.upc=concat('LC',convert(v.likecode,char))
                     INNER JOIN batches AS b ON b.batchID=l.batchID
                     " . ($isHQ ? ' INNER JOIN StoreBatchMap AS m ON b.batchID=m.batchID and p.store_id=m.storeID ' : '') . "
-                SET p.special_price = l.salePrice,
-                    p.end_date = b.endDate,
-                    p.start_date=b.startDate,
+                SET p.start_date = b.startDate,
+                    p.end_date=b.endDate,
+                    p.special_price=CASE WHEN l.pricemethod=2 THEN p.normal_price ELSE l.salePrice END,
                     p.specialgroupprice=CASE WHEN l.salePrice < 0 THEN -1*l.salePrice ELSE l.salePrice END,
                     p.specialpricemethod=l.pricemethod,
                     p.specialquantity=l.quantity,

--- a/fannie/cron/tasks/SalesBatchTask.php
+++ b/fannie/cron/tasks/SalesBatchTask.php
@@ -165,6 +165,11 @@ class SalesBatchTask extends FannieTask
                 // list of UPCs that should be on sale
                 $sale_upcs = $this->addSaleUPC($sale_upcs, $upc, $product->store_id());
 
+                // for qtyEnforcedGroupPM the salePrice is the whole group price
+                if ($specialpricemethod == 2) {
+                    $special_price = $product->normal_price();
+                }
+
                 $changed = false;
                 if ($product->special_price() != $special_price) {
                     $changed = true;


### PR DESCRIPTION
Scheduling or forcing a sales batch doesn't correctly set the underlying columns for QttyEnforcedPM (i.e., 3-for-$1). The description [here](https://github.com/CORE-POS/IS4C/wiki/Additional-Pricing-Methods#price-method-2-qttyenforcedgrouppm) is accurate. In the case of a sale, `specialgroupprice` has to be the full set price and `special_price` has to be the individual item price. The batch process was setting both these columns to the full set price.