### PR TITLE
Fannie Standard shelftag improvements

### DIFF
--- a/fannie/admin/labels/FpdfWithBarcode.php
+++ b/fannie/admin/labels/FpdfWithBarcode.php
@@ -9,12 +9,14 @@ class FpdfWithBarcode extends FPDF
 {
    function EAN13($x,$y,$barcode,$h=16,$w=.35)
    {
-      $this->Barcode($x,$y,$barcode,$h,$w,13);
+      $numDigits = strlen(ltrim($barcode, '0')) <= 11 ? 12 : 13;
+      $this->Barcode($x,$y,$barcode,$h,$w,$numDigits);
    }
 
    function UPC_A($x,$y,$barcode,$h=16,$w=.35)
    {
-      $this->Barcode($x,$y,$barcode,$h,$w,12);
+      $numDigits = strlen(ltrim($barcode, '0')) <= 11 ? 12 : 13;
+      $this->Barcode($x,$y,$barcode,$h,$w,$numDigits);
     }
 
     function GetCheckDigit($barcode)

--- a/fannie/admin/labels/genLabels.php
+++ b/fannie/admin/labels/genLabels.php
@@ -111,7 +111,9 @@ class genLabels extends FannieRESTfulPage
                 $count = $row['count'];
             }
             for ($i=0; $i<$count; $i++) {
-                if (strlen($row['sku']) > 7) {
+                if ($row['sku'] == $row['upc']) {
+                    $row['sku'] = '';
+                } elseif (strlen($row['sku']) > 7) {
                     $row['sku'] = ltrim($row['sku'], '0');
                 }
                 $myrow = array(
@@ -149,6 +151,11 @@ class genLabels extends FannieRESTfulPage
         $result = $dbc->execute($testQ,$args);
         $data = array();
         while ($row = $dbc->fetchRow($result)) {
+            if ($row['sku'] == $row['upc']) {
+                $row['sku'] = '';
+            } elseif (strlen($row['sku']) > 7) {
+                $row['sku'] = ltrim($row['sku'], '0');
+            }
             $myrow = array(
             'normal_price' => $row['normal_price'],
             'description' => $row['description'],

--- a/fannie/admin/labels/pdf_layouts/Fannie_Standard.php
+++ b/fannie/admin/labels/pdf_layouts/Fannie_Standard.php
@@ -129,8 +129,8 @@ if (!class_exists('FpdfWithBarcode')) {
         $brand = ucwords(strtolower(substr($row['brand'],0,13)));
         $pak = $row['units'];
         $size = $row['units'] . "-" . $row['size'];
-        $sku = $row['sku'];
-        $upc = substr($row['upc'],1,12);
+        $sku = ($row['sku'] == $row['upc']) ? "" : $row['sku'];
+        $upc = ltrim($row['upc'],0);
         /** 
         * determine check digit using barcode.php function
         */
@@ -144,6 +144,7 @@ if (!class_exists('FpdfWithBarcode')) {
         /**
         * begin creating tag
         */
+        $pdf->SetFont('Arial','',10);
         $pdf->SetXY($genLeft, $descTop);
         $pdf->Cell($w,4,substr($desc,0,20),0,0,'L');
         $pdf->SetXY($genLeft,$brandTop);
@@ -152,7 +153,6 @@ if (!class_exists('FpdfWithBarcode')) {
         $pdf->Cell($w/2,4,$size,0,0,'L');
         $pdf->SetXY($priceLeft+9,$skuTop);
         $pdf->Cell($w/3,4,$tagdate,0,0,'R');
-        // $pdf->SetFont('Arial','',10);
         $pdf->SetXY($genLeft,$skuTop);
         $pdf->Cell($w/3,4,$sku,0,0,'L');
         $pdf->SetXY($vendLeft,$skuTop);
@@ -164,7 +164,10 @@ if (!class_exists('FpdfWithBarcode')) {
         * add check digit to pid from testQ
         */
         $newUPC = $upc . $check;
-        $pdf->UPC_A($barLeft,$barTop,$upc,7);
+        if (strlen($upc) <= 11)
+            $pdf->UPC_A($barLeft,$barTop,$upc,7);
+        else
+            $pdf->EAN13($barLeft,$barTop,$upc,7);
         /**
         * increment label parameters for next label
         */

--- a/fannie/classlib2.0/item/FannieSignage.php
+++ b/fannie/classlib2.0/item/FannieSignage.php
@@ -149,6 +149,9 @@ class FannieSignage
             if ($row['pricePerUnit'] == '') {
                 $row['pricePerUnit'] = PriceLib::pricePerUnit($row['normal_price'], $row['size']);
             }
+            if ($row['sku'] == $row['upc']) {
+                $row['sku'] = '';
+            }
             if (!isset($row['signMultiplier'])) {
                 $row['signMultiplier'] = 1;
             }


### PR DESCRIPTION
The need for the change to establishing the base upc was discovered at New Orleans Food Co-op and again at East Lansing.
SKUs that are the same as UPCs don't fit on the label and generally don't add new information.
Re-setting the font for each label is needed because otherwise all tags except the first are in the smaller font of the UPC.