### PR TITLE
BUGFIX: multistore dept selections stay in sync

### DIFF
--- a/fannie/item/modules/BaseItemModule.php
+++ b/fannie/item/modules/BaseItemModule.php
@@ -675,12 +675,20 @@ HTML;
                 callback:function(){
                     \$('#department{$store_id}').trigger('chosen:updated');
                     baseItem.chainSubs({$store_id});
+                    var opts = $('#department{$store_id}').html();
+                    $('.chosen-dept').each(function(i, e) {
+                        if (e.id != 'department{$store_id}') {
+                            $(e).html(opts);
+                            $(e).trigger('chosen:updated');
+                            baseItem.chainSubs(e.id.substring(10));
+                        }
+                    });
                 }
             });">
             {$superOpts}
         </select>
         <select name="department[]" id="department{$store_id}" 
-            class="form-control chosen-select syncable-input" 
+            class="form-control chosen-select chosen-dept syncable-input"
             onchange="baseItem.chainSubs({$store_id});">
             {$deptOpts}
         </select>


### PR DESCRIPTION
When superdepartment changes on the visible item, normal
syncing carries it through to other tab(s) but the department
selection, chosen, subdepts, tax/fs/etc all need to be
triggered manually