### PR TITLE
Prevent refund flagging on "RF" in Product Search

### DIFF
--- a/pos/is4c-nf/parser/preparse/Refund.php
+++ b/pos/is4c-nf/parser/preparse/Refund.php
@@ -30,12 +30,16 @@ class Refund extends PreParser
     
     function check($str)
     {
-        // ignore comments; they may have all sorts of
-        // random character cominations
-        if (substr($str, 0, 2) == "CM") {
+        /* Ignore product searches and comments; they may have all sorts of
+         * random character combinations.
+         */
+        if (
+            substr($str, -2, 2) == "PV" ||
+            substr($str, 0, 2) == "PV" ||
+            substr($str, 0, 2) == "CM"
+        ) {
             return false;
         }
-
 
         if (strstr($str, 'RF')) {
             // void and refund cannot combine


### PR DESCRIPTION
Product search string "fisherfolkPV" led to the CoreLocal refund flag being set.

Preparse modules :
* NR NoReceiptPreParse.php
* DI/PD PercentDiscount.php
* "*" Quantity.php
* DN/FN TagToggleFSDisc (already has the CM check)
might also benefit from this check.

It might even be good to put it in AjaxParser and skip the first parse chain entirely for Comments and Product Searches.

Also suggest that store-specific preparse routines such as WFCFixup check for store before executing.