### PR TITLE
Excel format descriptions reduced to first char

### DIFF
--- a/fannie/classlib2.0/FannieReportPage.php
+++ b/fannie/classlib2.0/FannieReportPage.php
@@ -894,14 +894,14 @@ class FannieReportPage extends FanniePage
                 );
                 $xlsdata = array_merge(array_reduce($this->report_description_content(), 
                     function($carry, $line) {
-                        $carry[] = strip_tags($line);
+                        $carry[] = array(strip_tags($line));
                         return $carry;
                     },
                     array()
                 ),$xlsdata); // prepend
                 $xlsdata = array_merge(array_reduce($this->defaultDescriptionContent(count($data)), 
                     function($carry, $line) {
-                        $carry[] = strip_tags($line);
+                        $carry[] = array(strip_tags($line));
                         return $carry;
                     },
                     array() 


### PR DESCRIPTION
If the elements of the array `$carry` at L#897 and L#904 are not arrays the resulting Excel single-cell row contains only the first character of `$line`.