### PR TITLE
Fix erasing too-deep sign price

### DIFF
--- a/fannie/classlib2.0/item/signage/Signage16UpP.php
+++ b/fannie/classlib2.0/item/signage/Signage16UpP.php
@@ -77,9 +77,17 @@ class Signage16UpP extends \COREPOS\Fannie\API\item\FannieSignage
             $pdf->SetX($this->left + ($this->width*$column));
             $y = $pdf->GetY();
             $pdf->MultiCell($effective_width, 8, $price, 0, 'C');
+            /* If the current vertical position of the cursor indicates
+             * that the price caused a line break
+             * - "erase" the price by writing a white rectangle over it
+             * - reduce the font size
+             * - try again
+             */
             if ($pdf->GetY() - $y > 8) {
                 $pdf->SetFillColor(0xff, 0xff, 0xff);
-                $pdf->Rect($this->left + ($this->width*$column), $y, $this->left + ($this->width*$column) + $effective_width, $pdf->GetY(), 'F');
+                $pdf->Rect($this->left + ($this->width*$column), ($y-2), 
+                           $this->left + ($this->width*$column) + $effective_width, 
+                           $pdf->GetY(), 'F');
                 $font_shrink++;
                 if ($font_shrink >= $this->BIG_FONT) {
                     break;


### PR DESCRIPTION


I find that the the too-deep (line breaks) price doesn't quite get erased, so I moved the vertical coordinate up a bit. A hack admittedly. I don't know why the cursor position when `MultiCell()` was called for the price and the vertical parameter for the overwrite `Rect()` are not the same.
![screenshot_051917_093618_pm](https://cloud.githubusercontent.com/assets/1131922/26272063/db817c46-3cdd-11e7-9e8b-b8a475706377.jpg)

Sorry about redundant issue, you can't put pictures in the initial note to the patch.