### PR TITLE
Check whether _GET['max'] exists

### DIFF
--- a/fannie/modules/plugins2.0/TimesheetPlugin/TimesheetPage.php
+++ b/fannie/modules/plugins2.0/TimesheetPlugin/TimesheetPage.php
@@ -25,7 +25,11 @@ class TimesheetPage extends FanniePage
         $this->title = 'Fannie - Administration Module';
         $this->display_func = '';
 
-        $max = ($_GET['max']) ? 10 : 10;  // Max number of entries.
+        if (isset($_GET['max'])) {
+            $max = ($_GET['max']) ? 10 : 10;  // Max number of entries.
+        } else {
+            $max = 10;
+        }
 
         if (!$this->current_user && $_GET['login'] == 1 ) {
             $this->loginRedirect();


### PR DESCRIPTION
This test keeps an error from being logged; max never seems to exist at least on initial display of the page.

Given the assignment options maybe simpler to just: $max = 10;