### PR TITLE
MemberLib CoreLane missing backslash

### DIFF
--- a/pos/is4c-nf/lib/MemberLib.php
+++ b/pos/is4c-nf/lib/MemberLib.php
@@ -136,7 +136,7 @@ class MemberLib
 
             \CoreLocal::set("memMsg", $memMsg);
             \CoreLocal::set("memMsg", $memMsg . _(' : Intra Coop spent: $') .
-               number_format(((float)CoreLocal::get("balance") * 1),2)
+               number_format(((float)\CoreLocal::get("balance") * 1),2)
             );
 
             if ($member < 99000) {
@@ -224,12 +224,12 @@ class MemberLib
 
                     // Store Charge
                     \CoreLocal::set("memMsg", $memMsg . _(' : Store Charge: $') .
-                        number_format(((float)CoreLocal::get("availBal") * 1),2)
+                        number_format(((float)\CoreLocal::get("availBal") * 1),2)
                     );
                     // Prepay
                     if ($limit == 0.00) {
                         \CoreLocal::set("memMsg", $memMsg . _(' : Pre Pay: $') .
-                            number_format(((float)CoreLocal::get("availBal") * 1),2)
+                            number_format(((float)\CoreLocal::get("availBal") * 1),2)
                         );
                     }
                 }
@@ -333,7 +333,7 @@ class MemberLib
             $prep = $conn->prepare('SELECT discount, staff, ssi 
                                     FROM memtype
                                     WHERE memtype=?');
-            $res = $conn->execute($prep, array((int)CoreLocal::get('memType')));
+            $res = $conn->execute($prep, array((int)\CoreLocal::get('memType')));
             if ($conn->numRows($res) > 0) {
                 $mtRow = $conn->fetchRow($res);
                 $row['Discount'] = $mtRow['discount'];


### PR DESCRIPTION
Upon `99999ID`    

Sep 13 02:19:13 x.y.coop corepos[30209]: (debug) include_once(/var/www/IS4C/pos/is4c-nf/lib/../lib/CoreLocal.php): failed to open stream: No such file or directory Line 100, /var/www/IS4C/pos/is4c-nf/lib/AutoLoader.php
Sep 13 02:19:13 x.y.coop corepos[30209]: (debug) include_once(): Failed opening '/var/www/IS4C/pos/is4c-nf/lib/../lib/CoreLocal.php' for inclusion (include_path='/var/www/IS4C/vendor/phpunit/php-file-iterator:.:/usr/share/php:/usr/share/pear') Line 100, /var/www/IS4C/pos/is4c-nf/lib/AutoLoader.php
[13-Sep-2017 02:19:13 America/New_York] PHP Fatal error:  Class 'COREPOS\pos\lib\CoreLocal' not found in /var/www/IS4C/pos/is4c-nf/lib/MemberLib.php on line 336
Sep 13 02:19:13 x.y.coop corepos[30209]: (debug) Class 'COREPOS\pos\lib\CoreLocal' not found Line 336, /var/www/IS4C/pos/is4c-nf/lib/MemberLib.php

`CoreLocal.php` is in `lib/LocalStorage/`

Adding the backslash at `L#336` prevents the error but I don't know whether it is the basic problem.  Changing to another member `484ID` gets the error at `L#129`.  Added backslashes at lines 227, 232 because the pattern is similar.

My version of `AutoLoader.php` has an extra branch that is not in `CORE-POS` but defeating it doesn't result in the backslashless `CoreLocal`s work.  (I'm happy to remove the extra branch if it isn't needed. I don't remember what it handled and it doesn't appear upstream at least under my name.
```
        if (!isset($map[$name]) && strpos($name, '\\') > 0) {
            if ($name[0] == '\\') { // some old PHP5.3 versions leave the leading backslash
                $name = substr($name, 1);
            }
            $sep = DIRECTORY_SEPARATOR;
            if (strpos($name, 'COREPOS\\common\\') === 0) {
                $ourPath = __DIR__ . $sep . '..' . $sep . '..' . $sep . '..' . $sep . 'common' . $sep . strtr(substr($name, 15), '\\', $sep) . '.php';
                $map[$name] = $ourPath;
                CoreLocal::set('ClassLookup', $map);
            } elseif (strpos($name, 'COREPOS\\pos\\') === 0) {
                $ourPath = __DIR__ . $sep . '..' . $sep . strtr(substr($name, 12), '\\', $sep) . '.php';
                $map[$name] = $ourPath;
                CoreLocal::set('ClassLookup', $map);
            }
            // 7May2016 EL This additional == 0 branch shouldn't be needed, but is at the moment.
        } elseif (!isset($map[$name]) && strpos($name, '\\') == 0) {
            $pieces = explode('\\', $name);
            $x = array_shift($pieces);
            $s = DIRECTORY_SEPARATOR;
            if (count($pieces) > 2 && $pieces[0] == 'COREPOS' && $pieces[1] == 'common') {
                $path = dirname(__FILE__) . $s . '..' . $s . '..' . $s . '..' . $s . 'common' . $s;
                $path .= self::arrayToPath(array_slice($pieces, 2));
                if (file_exists($path)) {
                    $map[$name] = $path;
                }
            } elseif (count($pieces) > 2 && $pieces[0] == 'COREPOS' && $pieces[1] == 'pos') {
                $path = dirname(__FILE__) . $s . '..' . $s;
                $path .= self::arrayToPath(array_slice($pieces, 2));
                if (file_exists($path)) {
                    $map[$name] = $path;
                }
            }
        } elseif (!isset($map[$name])) {
            // class is unknown
            // rebuild map to see if the definition
            // file has been added
            $map = self::loadMap();
            if (!is_array($map)) {
                return;
            }
        }

        if (isset($map[$name]) && !class_exists($name,false)) {
            $included = include_once($map[$name]); // #L100
            if ($included === false) {
                unset($map[$name]);
                CoreLocal::set('ClassLookup', $map);
            }
        }
```

Perhaps I should have filed this as an issue rather than a Pull Request.