### PR TITLE
Filtering method for formulas in Excel output formats

### DIFF
--- a/fannie/classlib2.0/FannieReportPage.php
+++ b/fannie/classlib2.0/FannieReportPage.php
@@ -21,6 +21,8 @@
 
 *********************************************************************************/
 
+use COREPOS\Fannie\API\data\FileData;
+
 if (!class_exists('FanniePage')) {
     include_once(dirname(__FILE__).'/FanniePage.php');
 }
@@ -1142,7 +1144,8 @@ class FannieReportPage extends FanniePage
         $item = preg_replace("/(\d) *%$/","$1",$item);
         // 1,000 -> 1000
         $item = preg_replace("/(\d),(\d\d\d)/","$1$2",$item);
-        return $item;
+
+        return FileData::excelNoFormula($item);
     }
 
     /**

--- a/fannie/classlib2.0/data/FileData.php
+++ b/fannie/classlib2.0/data/FileData.php
@@ -158,6 +158,51 @@ class FileData
         return date('Y-m-d H:i:s', mktime($hour, $minutes, $seconds, 1, $days-1, 1900));
     }
 
+    /**
+      Reduce potential for CSV based exploits
+
+      Different spreadsheet software *may* interpret values in CSVs/TSVs
+      that begin with =, @, +, or - as forumals and cause the spreadsheet to
+      execute the cell's value. This may or may not include user-facing 
+      warning messages.
+
+      One common solution is to prefix such fields with single quote ('). I'm
+      not using that option since it creates different headaches for users trying
+      to use the CSV/TSV as a data interchange format rather than just look at
+      it in Excel. Instead:
+
+      1. Leading =, @, or + characters are simply removed. This should include multiples,
+         e.g. "=@+=1+1" becomes "1+1". This creates a small set of strings that cannot
+         be used as product names, brands, etc but should be an OK compromise.
+      2. Values with a leading - do need to be allowed. This are validated as either
+         negative integers (-123) or negative floats (-123.45).
+    */
+    public static function excelNoFormula($str)
+    {
+        $first = substr(trim($str), 0, 1);
+        while ($first == '=' || $first == '@' || $first == '+' || $first == '-') {
+            $str = trim($str);
+            switch (substr($str, 0, 1)) {
+                case '-':
+                    if (preg_match('/^-[0-9]+\.[0-9]+$/', $str) || preg_match('/^-[0-9]+$/', $str)) {
+                        return $str;
+                    }
+                    return 'badval';
+                    break;
+
+                case '=':
+                case '@':
+                case '+':
+                default:
+                    $str = substr($str, 1);
+                    break;
+            }
+            $first = substr(trim($str), 0, 1);
+        }
+
+        return $str;
+    }
+
 }
 
 }

--- a/tests/fannie/ApiLibTest.php
+++ b/tests/fannie/ApiLibTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use COREPOS\Fannie\API\data\FileData;
+
 /**
  * @backupGlobals disabled
  */
@@ -317,6 +319,24 @@ class ApiLibTest extends PHPUnit_Framework_TestCase
         ob_start();
         FannieDispatch::runPage('AdminIndexPage');
         ob_end_clean();
+    }
+
+    public function testFileData()
+    {
+        $expect = array(
+            '=asdf' => 'asdf',
+            '@asdf' => 'asdf',
+            '+asdf' => 'asdf',
+            ' +asdf' => 'asdf',
+            ' ++==@=asdf' => 'asdf',
+            '-123' => '-123',
+            '-123.45' => '-123.45',
+            '-=asdf' => 'badval',
+            ' -=asdf' => 'badval',
+        );
+        foreach ($expect as $input => $output) {
+            $this->assertEquals($output, FileData::excelNoFormula($input));
+        }
     }
 }
 


### PR DESCRIPTION
      Reduce potential for CSV based exploits

      Different spreadsheet software *may* interpret values in CSVs/TSVs
      that begin with =, @, +, or - as forumals and cause the spreadsheet to
      execute the cell's value. This may or may not include user-facing 
      warning messages.

      One common solution is to prefix such fields with single quote ('). I'm
      not using that option since it creates different headaches for users trying
      to use the CSV/TSV as a data interchange format rather than just look at
      it in Excel. Instead:

      1. Leading =, @, or + characters are simply removed. This should include multiples,
         e.g. "=@+=1+1" becomes "1+1". This creates a small set of strings that cannot
         be used as product names, brands, etc but should be an OK compromise.
      2. Values with a leading - do need to be allowed. This are validated as either
         negative integers (-123) or negative floats (-123.45).