### PR TITLE
Automatically prefix tender report class

### DIFF
--- a/pos/is4c-nf/lib/ReceiptBuilding/TenderReports/TenderReport.php
+++ b/pos/is4c-nf/lib/ReceiptBuilding/TenderReports/TenderReport.php
@@ -57,6 +57,9 @@ static public function printReport($class=false){
 static public function get($session)
 {
     $trClass = $session->get("TenderReportMod");
+    if ($trClass !== '' && strpos($trClass, '\\') === false && !class_exists($trClass)) {
+        $trClass = 'COREPOS\\pos\\lib\\ReceiptBuilding\\TenderReports\\' . $trClass;
+    }
     if ($trClass == '' || !class_exists($trClass)) {
         $trClass = 'COREPOS\\pos\\lib\\ReceiptBuilding\\TenderReports\\DefaultTenderReport';
     }


### PR DESCRIPTION
If the class isn't namespaced already and doesn't exist, try appending the default namespace. Addresses #980.