### PR TITLE
sync/special custdata to work in all sequences

### DIFF
--- a/fannie/sync/special/custdata.wfc.php
+++ b/fannie/sync/special/custdata.wfc.php
@@ -22,7 +22,7 @@
 *********************************************************************************/
 
 include(dirname(__FILE__).'/../../config.php');
-require_once(__DIR__ . '/generic.mysql.php');
+require(__DIR__ . '/generic.mysql.php');
 
 // on each MySQL lane, load the CSV file
 foreach($FANNIE_LANES as $lane) {


### PR DESCRIPTION
It seems that if this is not the first of a set of sync's    
`require_once(__DIR__ . '/generic.mysql.php');`    
is not included, so the table isn't synced.