### PR TITLE
Provide "empty" member date values when none specified by JSON data

### DIFF
--- a/fannie/classlib2.0/member/MemberREST.php
+++ b/fannie/classlib2.0/member/MemberREST.php
@@ -799,14 +799,14 @@ class MemberREST
             if (isset($json['startDate'])) {
                 $startDate = $json['startDate'];
                 if ($startDate == '') {
-                    $startDate = '0000-00-00';
+                    $startDate = NULL;
                 }
                 $dates->start_date($startDate);
             }
             if (isset($json['endDate'])) {
                 $endDate = $json['endDate'];
                 if ($endDate == '') {
-                    $endDate = '0000-00-00';
+                    $endDate = NULL;
                 }
                 $dates->end_date($endDate);
             }

--- a/fannie/classlib2.0/member/MemberREST.php
+++ b/fannie/classlib2.0/member/MemberREST.php
@@ -797,10 +797,18 @@ class MemberREST
         if (isset($json['startDate']) || isset($json['endDate'])) {
             $dates = self::getModel($dbc, 'MemDatesModel');
             if (isset($json['startDate'])) {
-                $dates->start_date($json['startDate']); 
+                $startDate = $json['startDate'];
+                if ($startDate == '') {
+                    $startDate = '0000-00-00';
+                }
+                $dates->start_date($startDate);
             }
             if (isset($json['endDate'])) {
-                $dates->end_date($json['endDate']); 
+                $endDate = $json['endDate'];
+                if ($endDate == '') {
+                    $endDate = '0000-00-00';
+                }
+                $dates->end_date($endDate);
             }
             $dates->card_no($id);
             if (!$dates->save()) {


### PR DESCRIPTION
was suddenly having an issue here with php 7.3.14, whereas previously had no
issue with php 7.0.33

I'm a bit uncertain if this is the appropriate fix here, so no pressure to merge this, although I'd like the bug fixed somehow.  You can see the bug in action [here](https://demo-fannie.rattailproject.org/mem/MemberEditor.php?memNum=7718) (as of this writing, b/c account has no "end" member date) - just have to hit the Save button.

Should also mention, PHP wasn't the only version to change - I upgraded to Debian 10 (from 9) and went to MariaDB 10.3.22 from (I think) 10.1.44 also.