### PR TITLE
Fix the "old" date used for InitLastSold

### DIFF
--- a/fannie/cron/tasks/one-time/InitLastSold.php
+++ b/fannie/cron/tasks/one-time/InitLastSold.php
@@ -53,7 +53,7 @@ class InitLastSold extends FannieTask
             WHERE upc=?');
 
         // really old date to ensure we get the whole history
-        $dlog = DTransactionsModel::selectDlog('1950-01-01', date('Y-m-d'));
+        $dlog = DTransactionsModel::selectDlog('1970-01-02', date('Y-m-d'));
 
         $missingR = $dbc->query('
             SELECT upc


### PR DESCRIPTION
1950 was *too* old, and caused result of `strtotime()` to be negative, which
then caused `$dlog` to be set to 'core_trans.dlog' instead of
'trans_archive.dlogBig'