### PR TITLE
Treat the "last modified" `vendorItems` record as pseudo-default

### DIFF
--- a/fannie/classlib2.0/data/models/op/ProductsModel.php
+++ b/fannie/classlib2.0/data/models/op/ProductsModel.php
@@ -128,6 +128,10 @@ class ProductsModel extends BasicModel
             return $obj->getTagData($this->connection, $this->upc(), $price);
         }
 
+        // note that we only use the first result row from the query below,
+        // however it is possible for there to be multiple results due to the
+        // vendorItems join.  so here we sort by timestamp to get a
+        // deterministic pseudo-default, in cases where it is ambiguous
         $query = '
             SELECT p.upc,
                 p.description,
@@ -142,7 +146,8 @@ class ProductsModel extends BasicModel
             FROM products AS p
                 LEFT JOIN vendors AS v ON p.default_vendor_id=v.vendorID
                 LEFT JOIN vendorItems AS i ON p.upc=i.upc AND v.vendorID=i.vendorID
-            WHERE p.upc=?';
+            WHERE p.upc=?
+            ORDER BY i.modified DESC';
         $prep = $this->connection->prepare($query);
         $res = $this->connection->execute($prep, array($this->upc()));
 

--- a/fannie/item/modules/VendorItemModule.php
+++ b/fannie/item/modules/VendorItemModule.php
@@ -71,7 +71,10 @@ class VendorItemModule extends \COREPOS\Fannie\API\item\ItemModule {
         }
         $ret .= '</select>';
 
-        $prep = $dbc->prepare('SELECT * FROM vendorItems WHERE vendorID=? AND upc=?');
+        // we only use the first record for each vendor below, so here we sort
+        // by timestamp to get a deterministic pseudo-default, in cases where
+        // it is otherwise ambiguous
+        $prep = $dbc->prepare('SELECT * FROM vendorItems WHERE vendorID=? AND upc=? ORDER BY modified DESC');
         $style = ($matched) ? 'display:none;' : 'display:table;';
         $cost_class = '';
         foreach ($vendors as $id => $name) {


### PR DESCRIPTION
for when a product has multiple `vendorItems` for a certain vendor, this at
least gives us a deterministic way to choose a default, so it's not completely
random.  there may be other places which need similar tweaks yet.