### PR TITLE
Tendermodule editor

### DIFF
--- a/fannie/admin/Tenders/TenderEditor.php
+++ b/fannie/admin/Tenders/TenderEditor.php
@@ -208,7 +208,7 @@ class TenderEditor extends FannieRESTfulPage
         $ret = '<table class="table">
             <tr><th>Code</th><th>Name</th><th>Change Type</th>
             <th>Change Msg</th><th>Min</th><th>Max</th>
-            <th>Refund Limit</th><th>Account #</th></tr>';
+            <th>Refund Limit</th><th>TenderModule</th><th>Account #</th></tr>';
 
         foreach($model->find('TenderID') as $row){
             $ret .= sprintf('<tr>

--- a/fannie/admin/Tenders/TenderEditor.php
+++ b/fannie/admin/Tenders/TenderEditor.php
@@ -44,6 +44,7 @@ class TenderEditor extends FannieRESTfulPage
         $this->addRoute('post<id><saveMin>');
         $this->addRoute('post<id><saveMax>');
         $this->addRoute('post<id><saveRLimit>');
+        $this->addRoute('post<id><saveModule>');
         $this->addRoute('post<id><saveSalesCode>');
         $this->addRoute('post<newTender>');
 
@@ -147,6 +148,19 @@ class TenderEditor extends FannieRESTfulPage
         return false;
     }
 
+    protected function post_id_saveModule_handler()
+    {
+        if (is_numeric($this->saveModule)) {
+            echo "Error: Module must be text";
+        } else {
+            $model = $this->getTenderModel($this->id);
+            $model->TenderModule($this->saveModule);
+            $model->save();
+        }
+
+        return false;
+    }
+
     protected function post_id_saveSalesCode_handler()
     {
         if (!is_numeric($this->saveSalesCode)) {
@@ -226,7 +240,9 @@ class TenderEditor extends FannieRESTfulPage
                     <input size="6" maxlength="10" value="%.2f"
                     class="form-control price-field"
                     onchange="tenderEditor.saveRLimit.call(this, this.value,%d);" />
-                </div></td>
+                <td><input size="10" maxlength="50" value="%s"
+                    class="form-control"
+                    onchange="tenderEditor.saveModule.call(this, this.value,%d);" /></td>
                 <td><input size="10" value="%s"
                     class="form-control"
                     onchange="tenderEditor.saveSalesCode.call(this, this.value, %d);" /></td>
@@ -238,6 +254,7 @@ class TenderEditor extends FannieRESTfulPage
                 $row->MinAmount(),$row->TenderID(),
                 $row->MaxAmount(),$row->TenderID(),
                 $row->MaxRefund(),$row->TenderID(),
+				$row->TenderModule(),$row->TenderID(),
                 $row->SalesCode(),$row->TenderID()
             );
         }

--- a/fannie/admin/Tenders/edit.js
+++ b/fannie/admin/Tenders/edit.js
@@ -59,6 +59,10 @@ var tenderEditor = (function($) {
         _saveField('saveRLimit', val, t_id, this);
     };
 
+    mod.saveModule = function(val,t_id){
+        _saveField('saveModule', val, t_id, this);
+    };
+	
     mod.saveSalesCode = function(val, t_id){
         _saveField('saveSalesCode', val, t_id, this);
     };

--- a/pos/is4c-nf/scale-drivers/drivers/NewMagellan/SPH_Datacap_EMVX.cs
+++ b/pos/is4c-nf/scale-drivers/drivers/NewMagellan/SPH_Datacap_EMVX.cs
@@ -733,6 +733,7 @@ public class SPH_Datacap_EMVX : SerialPortHandler
             case "INGENICOISC250":
             case "INGENICOISC250_MERCURY_E2E":
             case "INGENICOISC250_RAPIDCONNECT_E2E":
+            case "INGENICOLANE8000_MERCURY":
                 return ComPortUtility.FindComPort("Ingenico");
             default:
                 return "";
@@ -755,6 +756,8 @@ public class SPH_Datacap_EMVX : SerialPortHandler
             case "INGENICOISC480":
             case "INGENICOISC480_RAPIDCONNECT_E2E":
                 return "ISC480";
+            case "INGENICOLANE8000_MERCURY":
+                return "LANE8000";
             default:
                 return device;
         }
@@ -776,6 +779,8 @@ public class SPH_Datacap_EMVX : SerialPortHandler
                 return "EMV_ISC250_RAPIDCONNECT_E2E";
             case "INGENICOISC480_RAPIDCONNECT_E2E":
                 return "EMV_ISC480_RAPIDCONNECT_E2E";
+            case "INGENICOLANE8000_MERCURY":
+                return "EMV_LANE8000_MERCURY";
             default:
                 return "EMV_" + device;
         }

--- a/pos/is4c-nf/scale-drivers/drivers/NewMagellan/SPH_Datacap_Gen2.cs
+++ b/pos/is4c-nf/scale-drivers/drivers/NewMagellan/SPH_Datacap_Gen2.cs
@@ -865,6 +865,7 @@ public class SPH_Datacap_Gen2 : SerialPortHandler
                 return ComPortUtility.FindComPort("Verifone");
             case "INGENICOISC250":
             case "INGENICOISC250_MERCURY_E2E":
+            case "INGENICOLANE8000_MERCURY":
             case "INGENICOISC250_RAPIDCONNECT_E2E":
                 return ComPortUtility.FindComPort("Ingenico");
             default:
@@ -887,6 +888,8 @@ public class SPH_Datacap_Gen2 : SerialPortHandler
                 return "ISC250";
             case "INGENICOIPP320":
                 return "IPP320";
+            case "INGENICOLANE8000_MERCURY":
+                return "LANE8000";
             default:
                 return device;
         }
@@ -908,6 +911,8 @@ public class SPH_Datacap_Gen2 : SerialPortHandler
                 return "EMV_ISC250_RAPIDCONNECT_E2E";
             case "INGENICOIPP320":
                 return "EMV_IPP320_RAPIDCONNECT";
+            case "INGENICOLANE8000_MERCURY":
+                return "EMV_LANE8000_MERCURY";
             default:
                 return "EMV_" + device;
         }


### PR DESCRIPTION
Adds in `TenderModule` support to the CORE-Office Tender editor.  So that Tenders can be managed on the server and safely synced to lanes w/o clobbering local `TenderModule` settings.

PS: the Ingenico Tetra devices commit snuck in here by accident.