### PR TITLE
Let MemberREST handle saving card data, instead of MemCard module

### DIFF
--- a/fannie/mem/modules/MemCard.php
+++ b/fannie/mem/modules/MemCard.php
@@ -148,17 +148,8 @@ class MemCard extends \COREPOS\Fannie\API\member\MemberModule {
             $form_upc = sprintf("{$prefix}%0{$clen}d", $form_upc);
         }
 
-        $model = new MemberCardsModel($dbc);
-        $model->card_no($memNum);
-        $model->upc($form_upc);
-        $saved = $model->save();
-        $model->pushToLanes();
-
-        if (!$saved) {
-            return 'Error: problem saving Member Card<br />';
-        } else {
-            return '';
-        }
+        $json['idCardUPC'] = $form_upc;
+        return $json;
 
     // saveFormData
     }


### PR DESCRIPTION
module should only be responsible for figuring out new data to be saved

this has something to do with API changes made for #681

Without this change, a member with empty card UPC would be updated correctly by the module, but then MemberREST would be called with stale account data, so the old UPC then gets saved again.