### PR TITLE
Avoid writing empty string for birthdate when adding cashier

### DIFF
--- a/fannie/admin/Cashiers/AddCashierPage.php
+++ b/fannie/admin/Cashiers/AddCashierPage.php
@@ -63,7 +63,9 @@ class AddCashierPage extends FannieRESTfulPage
         $employee->EmpActive(1);
         $employee->frontendsecurity($this->fes);
         $employee->backendsecurity($this->fes);
-        $employee->birthdate($this->birthdate);
+        if ($this->birthdate) {
+            $employee->birthdate($this->birthdate);
+        }
         $employee->save();
 
         try {


### PR DESCRIPTION
since newer mysql now comes with STRICT_TRANS_TABLES enabled

Without this, if MySQL is using [STRICT_TRANS_TABLES](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_strict_trans_tables) as part of its "SQL Mode" then adding a cashier with no birthdate will fail, because it tried to write an empty string for that column value.