### PR TITLE
Add new GitStatus plugin/task

### DIFF
--- a/fannie/modules/plugins2.0/GitStatus/GitStatus.php
+++ b/fannie/modules/plugins2.0/GitStatus/GitStatus.php
@@ -5,11 +5,27 @@ class GitStatus extends COREPOS\Fannie\API\FanniePlugin
     public $plugin_description = 'Provides a scheduled task to check for "git status" issues in the source folder.';
 
     public $plugin_settings = array(
+        'GitStatusExecutable' => array(
+            'label'=>'Git executable',
+            'description'=>"Executable to use for Git.  Default of 'git' is fine in most cases.  If you need something else then it should probably be an absolute path.",
+            'default'=>'git'),
+        'GitStatusFetch' => array(
+            'label'=>'Git fetch',
+            'description'=>"Whether 'git fetch' should be ran at all.",
+            'options' => array("Do not use 'git fetch' (check 'git status' only)" => 'false',
+                               "Use 'git fetch' and compare local vs. remote" => 'true'),
+            'default'=>'false'),
         'GitStatusFetchWithSudo' => array(
             'label'=>'Fetch with sudo',
             'description'=>"Whether 'sudo' must be used when running 'git fetch' command.  Note that using sudo typically requires a corresponding entry in a 'sudoers' file, to obviate the need for password prompt.",
             'options' => array("Do not use sudo (e.g.: git fetch origin)" => 'false',
                                "Use sudo (e.g.: sudo -u owner git fetch origin)" => 'true'),
+            'default'=>'false'),
+        'GitStatusDebug' => array(
+            'label'=>'Debug mode',
+            'description'=>"Whether to print debug messages.  Note that cron will send email only when there is output.  (The plugin/task does not itself directly send email.)",
+            'options' => array("No debug messages (means no email unless problem is found)" => 'false',
+                               "Include debug messages (means email is always sent)" => 'true'),
             'default'=>'false'),
     );
 }

--- a/fannie/modules/plugins2.0/GitStatus/GitStatus.php
+++ b/fannie/modules/plugins2.0/GitStatus/GitStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+class GitStatus extends COREPOS\Fannie\API\FanniePlugin
+{
+    public $plugin_description = 'Provides a scheduled task to check for "git status" issues in the source folder.';
+
+    public $plugin_settings = array(
+        'GitStatusFetchWithSudo' => array(
+            'label'=>'Fetch with sudo',
+            'description'=>"Whether 'sudo' must be used when running 'git fetch' command.  Note that using sudo typically requires a corresponding entry in a 'sudoers' file, to obviate the need for password prompt.",
+            'options' => array("Do not use sudo (e.g.: git fetch origin)" => 'false',
+                               "Use sudo (e.g.: sudo -u owner git fetch origin)" => 'true'),
+            'default'=>'false'),
+    );
+}

--- a/fannie/modules/plugins2.0/GitStatus/GitStatusTask.php
+++ b/fannie/modules/plugins2.0/GitStatus/GitStatusTask.php
@@ -198,7 +198,7 @@ please see that for settings to control behavior.';
             if (!$this->identifyOwner($owner)) {
                 return false;
             }
-            exec("sudo -u $owner {$this->git} fetch $remote", $output, $return_var);
+            exec("sudo -u $owner -H {$this->git} fetch $remote", $output, $return_var);
         } else {
             exec("{$this->git} fetch $remote", $output, $return_var);
         }

--- a/fannie/modules/plugins2.0/GitStatus/GitStatusTask.php
+++ b/fannie/modules/plugins2.0/GitStatus/GitStatusTask.php
@@ -1,0 +1,234 @@
+<?php
+
+class GitStatusTask extends FannieTask
+{
+    public $name = 'Git Status';
+
+    public $description = 'Looks for "git status" issues
+(dirty git status etc.) in the source folder.
+
+NOTE: This task is provided by the GitStatus plugin;
+please see that for settings to control behavior.';
+
+    public $default_schedule = array(
+        'min' => 20,
+        'hour' => 4,
+        'day' => '*',
+        'month' => '*',
+        'weekday' => '*',
+    );
+
+    // NOTE: if you get output like the following then it probably means you
+    // are *not* currently using 'sudo' to run 'git fetch' but that you do need
+    // to use it.
+    //
+    //      error: cannot open .git/FETCH_HEAD: Permission denied
+    //      failed to fetch remote!  return_var is 255; output is:
+    //
+    // if you instead get output like the following, then it means you *are*
+    // using sudo, but have not yet configured the sudoers properly (below).
+    //
+    //      sudo: no tty present and no askpass program specified
+    //      failed to fetch remote!  return_var is 1; output is:
+    //
+    // if you do use 'sudo' when running 'git fetch' (which is likely to be the
+    // case) then you must also establish a 'sudoers' file entry, so that the
+    // command can be ran with no need for password prompt. if this is the case
+    // for you, then you must exlicitly allow www-data to do the fetch.  create
+    // or edit a sudoers file specific to CORE:
+    //
+    //      sudo visudo -f /etc/sudoers.d/corepos
+    //
+    // and add the following entry, replacing "myself" with the appropriate
+    // username, i.e. whoever is owner of the source folder:
+    //
+    //      www-data ALL = (myself) NOPASSWD: /usr/bin/git fetch origin
+
+    public function run()
+    {
+        // change to root dir of repo, to run our git commands
+        $rootdir = realpath(__DIR__ . '/../../../..');
+        // $this->stderr("rootdir is: $rootdir\n");
+        chdir($rootdir);
+
+        if (!$this->checkGitStatus()) {
+            return;
+        }
+
+        if (!$this->identifyGitBranch($branch, $remote, $remoteBranch)) {
+            return;
+        }
+
+        if (!$this->gitFetchRemote($remote)) {
+            return;
+        }
+
+        if (!$this->checkGitDiff($branch, $remote, $remoteBranch)) {
+            return;
+        }
+
+        // $this->stderr("made it to the end\n");
+    }
+
+    private function stderr($text)
+    {
+        $fh = fopen('php://stderr', 'a');
+        fwrite($fh, $text);
+        fclose($fh);
+    }
+
+    private function checkGitStatus()
+    {
+        // use --porcelain so we can assume "empty output means clean status"
+        exec('git status --porcelain', $output, $return_var);
+
+        if ($return_var) {
+            $this->stderr("failed to check git status!  ");
+            $this->showGitStatus();
+            return false;
+        }
+
+        if ($output) {
+            $this->stderr("git status is not clean!  ");
+            $this->showGitStatus();
+            return false;
+        }
+
+        // $this->stderr("git status is clean\n");
+        return true;
+    }
+
+    private function showGitStatus()
+    {
+        exec('git status', $output, $return_var);
+        $this->showCommandResult($return_var, $output);
+    }
+
+    private function showCommandResult($return_var, $output)
+    {
+        $this->stderr("return_var is $return_var; output is:\n\n" . implode("\n", $output) . "\n");
+    }
+
+    private function identifyGitBranch(&$branch, &$remote, &$remoteBranch)
+    {
+        exec('git status --branch --porcelain', $output, $return_var);
+
+        if ($return_var) {
+            $this->stderr("failed to identify git branch!  ");
+            $this->showGitStatus();
+            return false;
+        }
+
+        if (!$output) {
+            $this->stderr("could not determine git branch!  ");
+            $this->showGitStatus();
+            return false;
+        }
+
+        // parse local branch from output
+        $parts = explode('...', $output[0]);
+        $branch = substr($parts[0], 3); // trim off first 3 chars, i.e. '## '
+
+        // parse remote name, and remote branch
+        $remoteParts = explode('/', $parts[1]);
+        $remote = $remoteParts[0];
+        $remoteBranch = $remoteParts[1];
+
+        // $this->stderr("branch is: $branch\n");
+        // $this->stderr("remote is: $remote\n");
+        // $this->stderr("remoteBranch is: $remoteBranch\n");
+        return true;
+    }
+
+    private function identifyOwner(&$owner)
+    {
+        // do a simple "long list" of current folder
+        exec('ls -ld .', $output, $return_var);
+
+        if ($return_var) {
+            $this->stderr("failed to identify folder owner!  ");
+            $this->showCommandResult($return_var, $output);
+            return false;
+        }
+
+        if (!$output) {
+            $this->stderr("got no output from folder list!  ");
+            $this->showCommandResult($return_var, $output);
+            return false;
+        }
+
+        // parse owner username from output
+        $parts = explode(' ', $output[0]);
+        $owner = $parts[2];
+
+        // $this->stderr("folder owner is: $owner\n");
+        return true;
+    }
+
+    private function gitFetchRemote($remote)
+    {
+        $settings = $this->config->get('PLUGIN_SETTINGS');
+        $useSudo = $settings['GitStatusFetchWithSudo'] === 'true';
+
+        // run git fetch command, with or without sudo
+        if ($useSudo) {
+            if (!$this->identifyOwner($owner)) {
+                return false;
+            }
+            exec("sudo -u $owner git fetch $remote", $output, $return_var);
+        } else {
+            exec("git fetch $remote", $output, $return_var);
+        }
+
+        if ($return_var) {
+            $this->stderr("failed to fetch remote!  ");
+            $this->showCommandResult($return_var, $output);
+            return false;
+        }
+
+        if ($output) {
+            $this->stderr("unexpected output when fetching remote!  ");
+            $this->showCommandResult($return_var, $output);
+            return false;
+        }
+
+        // $this->stderr("remote commits were fetched\n");
+        return true;
+    }
+
+    private function checkGitDiff($branch, $remote, $remoteBranch)
+    {
+        // first look for remote commits not found in workdir
+        exec("git log ..$remote/$remoteBranch", $output, $return_var);
+
+        if ($return_var) {
+            $this->stderr("failed to check for unknown remote commits!  ");
+            $this->showCommandResult($return_var, $output);
+            return false;
+        }
+
+        if ($output) {
+            $this->stderr("$remote/$remoteBranch has commits not present in workdir!  ");
+            $this->showCommandResult($return_var, $output);
+            return false;
+        }
+
+        // next look for local commits not found in remote
+        exec("git log $remote/$remoteBranch..", $output, $return_var);
+
+        if ($return_var) {
+            $this->stderr("failed to check for unknown local commits!  ");
+            $this->showCommandResult($return_var, $output);
+            return false;
+        }
+
+        if ($output) {
+            $this->stderr("there are local commits not present in $remote/$remoteBranch!  ");
+            $this->showCommandResult($return_var, $output);
+            return false;
+        }
+
+        // $this->stderr("$remote/$remoteBranch and workdir match\n");
+        return true;
+    }
+}


### PR DESCRIPTION
this basically does sanity checks on the source folder, from which Office is
currently running:

- `git status` should be clean
- all local commits should exist in origin, and vice versa

Hoping this can be useful to remind one not to leave uncommitted changes laying around, or forget to push/pull between origin and production server.  Meant to run as an overnight scheduled task of course.  It tries to write helpful info to STDERR when the job runs, so email should go to whomever is configured for that in general.

This has yet to really be tried in production so it may need some tweaks along the way.  Let me know if you'd rather such refinements happen before this PR does.