### PR TITLE
parameters.param_value longer

### DIFF
--- a/pos/is4c-nf/lib/models/op/ParametersModel.php
+++ b/pos/is4c-nf/lib/models/op/ParametersModel.php
@@ -37,7 +37,7 @@ class ParametersModel extends BasicModel
     'store_id' => array('type'=>'SMALLINT', 'primary_key'=>true),
     'lane_id' => array('type'=>'SMALLINT', 'primary_key'=>true),
     'param_key' => array('type'=>'VARCHAR(100)', 'primary_key'=>true),
-    'param_value' => array('type'=>'VARCHAR(255)'),
+    'param_value' => array('type'=>'VARCHAR(512)'),
     'is_array' => array('type'=>'TINYINT'),
     );
 


### PR DESCRIPTION
I've seen a reasonable set of Tender Modules that was longer than 255 chars. I suggest VARCHAR(512), which is working at that site, but exactly 512 isn't necessary.