### PR TITLE
foreach() instead of each() in adodb.inc.php

### DIFF
--- a/common/adodb5/adodb.inc.php
+++ b/common/adodb5/adodb.inc.php
@@ -1164,7 +1164,8 @@ if (!defined('_ADODB_LAYER')) {
 				foreach($inputarr as $arr) {
 					$sql = ''; $i = 0;
 					//Use each() instead of foreach to reduce memory usage -mikefedyk
-					while(list(, $v) = each($arr)) {
+					// each() is deprecated as of PHP 7.2.0 and removed as of 8.0.0
+					foreach($arr as $v) {
 						$sql .= $sqlarr[$i];
 						// from Ron Baldwin <ron.baldwin#sourceprose.com>
 						// Only quote string types


### PR DESCRIPTION
The original `//while(list(, $v) = each($arr)) {` leads to huge numbers of warnings in the log for PHP 7.4.3 and perhaps earlier and docs for `each()` say:
"This function has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0."