### PR TITLE
Test for null before reporting fatal error

### DIFF
--- a/common/ErrorHandler.php
+++ b/common/ErrorHandler.php
@@ -101,10 +101,12 @@ class ErrorHandler
     static public function catchFatal()
     {
         $error = error_get_last();
-        if ($error["type"] == E_ERROR 
-            || $error['type'] == E_PARSE 
+        if (!is_null($error) &&
+            ($error['type'] == E_ERROR
+            || $error['type'] == E_PARSE
             || $error['type'] == E_CORE_ERROR
-            || $error['type'] == E_COMPILE_ERROR) {
+            || $error['type'] == E_COMPILE_ERROR)
+        ) {
             self::errorHandler($error["type"], $error["message"], $error["file"], $error["line"]);
             /**
               Put fatals in the error log as well as the debug log


### PR DESCRIPTION
This avoids some useless logging about the absence of `$error['type']` when `$error` is `null`.