### PR TITLE
Add 2 more columns to `GROUP BY` clause for DepartmentMovementReport

### DIFF
--- a/fannie/reports/DepartmentMovement/DepartmentMovementReport.php
+++ b/fannie/reports/DepartmentMovement/DepartmentMovementReport.php
@@ -143,9 +143,13 @@ class DepartmentMovementReport extends FannieReportPage
                       AND t.memType NOT IN {$nabs}
                       GROUP BY t.upc,
                           p.brand,
-                          CASE WHEN t.description IS NULL THEN p.description ELSE t.description END,
+                          description,
                           CASE WHEN t.trans_status = 'R' THEN 'Refund' ELSE 'Sale' END,
-                      d.dept_no,d.dept_name,s.superID,v.vendorName ORDER BY SUM(t.total) DESC";
+                          d.dept_no,d.dept_name,s.superID,
+                          v.vendorName,
+                          l.likeCode,
+                          l.likeCodeDesc
+                      ORDER BY SUM(t.total) DESC";
                 break;
             case 'Department':
                 $query =  "SELECT t.department,d.dept_name,"


### PR DESCRIPTION
this is to avoid a specific warning, e.g.:

    Expression #11 of SELECT list is not in GROUP BY clause and contains
    nonaggregated column 'core_op.l.likeCode' which is not functionally
    dependent on columns in GROUP BY clause; this is incompatible with
    sql_mode=only_full_group_by

I've really only tested this enough to confirm that it gives one less error, than running the report without this change would give.  But haven't really tested it enough (i.e. with enough data) to confirm the output is unaltered.  Logically though I can't think of any reason this isn't safe..?