### PR TITLE
Try harder to provide default limit for house coupon

### DIFF
--- a/fannie/modules/plugins2.0/HouseCoupon/HouseCouponEditor.php
+++ b/fannie/modules/plugins2.0/HouseCoupon/HouseCouponEditor.php
@@ -152,7 +152,7 @@ class HouseCouponEditor extends FanniePage
             if ($expires == '') {
                 $expires = null;
             }
-            $limit = FormLib::get_form_value('limit',1);
+            $limit = FormLib::get_form_value('limit',1) || 1;
             $mem = FormLib::get_form_value('memberonly',0);
             $dept = FormLib::get_form_value('dept',0);
             $dtype = FormLib::get_form_value('dtype','Q');


### PR DESCRIPTION
form value can come through as empty string, in which case the default value
was not being used