### PR TITLE
Skip composer checks for `corepos/office-plugin-*` packages

### DIFF
--- a/fannie/install/InstallIndexPage.php
+++ b/fannie/install/InstallIndexPage.php
@@ -169,9 +169,13 @@ class InstallIndexPage extends \COREPOS\Fannie\API\InstallPage {
             $obj = json_decode($json);
             $missing = false;
             foreach (get_object_vars($obj->require) as $package => $version) {
-                if (!is_dir(dirname(__FILE__) . '/../../vendor/' . $package)) {
-                    $missing = true;
-                    echo "<div class=\"alert alert-danger\"><b>Warning</b>: package " . $package . " is not installed.</div>";
+                if (preg_match('/^corepos\/office-plugin-/', $package)) {
+                    error_log("TODO: cannot confirm installation of CORE Office plugin: $package");
+                } else {
+                    if (!is_dir(dirname(__FILE__) . '/../../vendor/' . $package)) {
+                        $missing = true;
+                        echo "<div class=\"alert alert-danger\"><b>Warning</b>: package " . $package . " is not installed.</div>";
+                    }
                 }
             }
             if ($missing) {


### PR DESCRIPTION
those are installed differently and can't be checked in the same way

Actually it would be nice to still check for these, but I'm not yet sure how best to do that.  Such a plugin is written to a folder whose name is "derived" from the package name.  (See [notes](https://github.com/CORE-POS/ComposerInstaller/blob/master/README.md#name-mangling).)  The logic for deriving the name lives within `corepos/composer-installer` package and it'd be nice to leverage that here, but by definition we probably can't be certain that package is present...

This PR is just one idea so feel free to reject; mostly I'm trying to avoid this false alarm which otherwise would happen after installing a plugin, e.g. with:

```sh
php composer.phar require 'corepos/office-plugin-git-status:dev-master'
```

![Screenshot from 2021-04-14 18-20-25](https://user-images.githubusercontent.com/134969/114792903-d6b30b00-9d4e-11eb-9b48-6f4ca71955b0.png)
