### PR TITLE
Ignore "orphaned" SKU when saving product

### DIFF
--- a/fannie/item/modules/BaseItemModule.php
+++ b/fannie/item/modules/BaseItemModule.php
@@ -1163,6 +1163,7 @@ HTML;
             }
 
             $chkP = $dbc->prepare("SELECT upc FROM vendorItems
+                INNER JOIN products ON products.upc = vendorItems.upc
                 WHERE sku=? AND vendorID=? AND upc <> ?");
             $chk = $dbc->getValue($chkP, array($sku, $vendorID, $upc));
             if ($chk && $override == 0) {
@@ -1217,6 +1218,7 @@ HTML;
             $sku = FormLib::get('vendorSKU');
             if ($vendorID != 0 && $sku != '') {
                 $chkP = $dbc->prepare("SELECT upc FROM vendorItems
+                    INNER JOIN products ON products.upc = vendorItems.upc
                     WHERE sku=? AND vendorID=? AND upc <> ?");
                 $chk = $dbc->getValue($chkP, array($sku, $vendorID, $upc));
                 if ($chk) {


### PR DESCRIPTION
assuming the following:

- UPC 07430500132 exists in products but has no vendorItems record(s)
- UPC 07430500116 does not exist in products, but
- there is a vendorItems record with SKU 12345 and UPC 07430500116

with this commit, user is allowed to edit 1st item and assign it SKU
12345, even though that is associated with a different UPC.  since
there is not a corresponding products record, the vendorItems record
is considered "orphaned"

without this commit, user is not allowed to assign SKU to 1st item,
b/c of the orphaned vendorItems record.

the code change basically ignores orphaned records, so they do not
prevent user from taking desired action in this particular case.

This also relates to https://github.com/CORE-POS/IS4C/commit/e3eef017dbbcc8fae21568674ab2023267387f2d and https://github.com/CORE-POS/IS4C/commit/b1a1a4d49279d560ab8281794407e31bca3c8ff1