### PR TITLE
Add initial support for "Poser" concept

### DIFF
--- a/fannie/classlib2.0/FannieAPI.php
+++ b/fannie/classlib2.0/FannieAPI.php
@@ -284,7 +284,7 @@ class FannieAPI
         // prefer directories from Poser if present
         $poser = FannieConfig::config('POSER');
         if ($poser) {
-            $directories[] = "$poser/office-plugins/";
+            $directories[] = "$poser/office_plugins/";
         }
         $directories[] = dirname(__FILE__).'/../modules/plugins2.0/';
         // leading backslash is ignored

--- a/fannie/classlib2.0/FannieAPI.php
+++ b/fannie/classlib2.0/FannieAPI.php
@@ -197,6 +197,10 @@ class FannieAPI
             'COREPOS\\Fannie\\API\\' => dirname(__FILE__) . '/',
             'COREPOS\\Fannie\\Plugin\\' => dirname(__FILE__) . '/../modules/plugins2.0/',
         );
+        $poser = FannieConfig::config('POSER');
+        if ($poser) {
+            $namespaces[] = 'Poser\\' => $poser;
+        }
         $class = ltrim($class, '\\');
         foreach ($namespaces as $namespace => $path) {
             if (substr($class, 0, strlen($namespace)) == $namespace) {

--- a/fannie/classlib2.0/FannieAPI.php
+++ b/fannie/classlib2.0/FannieAPI.php
@@ -199,7 +199,7 @@ class FannieAPI
         );
         $poser = FannieConfig::config('POSER');
         if ($poser) {
-            $namespaces[] = 'Poser\\' => $poser;
+            $namespaces['Poser\\'] = $poser;
         }
         $class = ltrim($class, '\\');
         foreach ($namespaces as $namespace => $path) {

--- a/fannie/classlib2.0/FannieAPI.php
+++ b/fannie/classlib2.0/FannieAPI.php
@@ -277,15 +277,15 @@ class FannieAPI
     static private function searchDirectories($base_class)
     {
         $directories = array();
+        // prefer directories from Poser if present
+        $poser = FannieConfig::config('POSER');
+        if ($poser) {
+            $directories[] = "$poser/office-plugins/";
+        }
         $directories[] = dirname(__FILE__).'/../modules/plugins2.0/';
         // leading backslash is ignored
         if ($base_class[0] == '\\') {
             $base_class = substr($base_class, 1);
-        }
-
-        $poser = FannieConfig::config('POSER');
-        if ($poser) {
-            $directories[] = "$poser/fannie/modules/plugins2.0/";
         }
 
         switch($base_class) {

--- a/fannie/classlib2.0/FannieAPI.php
+++ b/fannie/classlib2.0/FannieAPI.php
@@ -283,6 +283,11 @@ class FannieAPI
             $base_class = substr($base_class, 1);
         }
 
+        $poser = FannieConfig::config('POSER');
+        if ($poser) {
+            $directories[] = "$poser/fannie/modules/plugins2.0/";
+        }
+
         switch($base_class) {
             case 'COREPOS\Fannie\API\item\ItemModule':
             case 'COREPOS\Fannie\API\item\ItemRow':

--- a/fannie/classlib2.0/FannieConfig.php
+++ b/fannie/classlib2.0/FannieConfig.php
@@ -42,6 +42,9 @@ class FannieConfig
                 }
             }
         }
+        if (isset($this->vars['FANNIE_POSER'])) {
+            $this->vars['FANNIE_POSER'] = rtrim($this->vars['FANNIE_POSER'], '/');
+        }
         if (file_exists(__DIR__ . '/../DEV_MODE')) {
             $this->vars['FANNIE_DEV_MODE'] = true;
         }

--- a/fannie/install/InstallThemePage.php
+++ b/fannie/install/InstallThemePage.php
@@ -103,6 +103,17 @@ class InstallThemePage extends \COREPOS\Fannie\API\InstallPage
             . '<td><img src="' . $FANNIE_CSS_LOGO . '" alt="logo preview" /></td>'
             . '</tr>';
 
+        echo '<tr><td>Poser path (optional)</td>'
+            . '<td>' . installTextField('FANNIE_POSER', $FANNIE_POSER, '') . '</td>'
+            . '</tr>';
+        if (isset($FANNIE_POSER) && $FANNIE_POSER) {
+            if ($FANNIE_POSER[0] != '/') {
+                echo '<tr><td colspan="4" class="alert-warning">You should use an absolute path to Poser</td></tr>';
+            } elseif (!is_dir($FANNIE_POSER)) {
+                echo '<tr><td colspan="4" class="alert-danger">Path to Poser is not valid</td></tr>';
+            }
+        }
+
         echo '</table>';
         $this_page = $_SERVER['REQUEST_URI'];
         $test_page = str_replace('install/InstallThemePage.php', 'install/util.php', $this_page);

--- a/pos/is4c-nf/install/extra_config.php
+++ b/pos/is4c-nf/install/extra_config.php
@@ -516,6 +516,19 @@ while($row = $db->fetch_row($res)){
     <td><b><?php echo _('Redis Host'); ?></b>:</td>
     <td><?php echo $form->textField('redistHost', CoreLocal::get('mServer')); ?></td>
 </tr>
+<tr><td colspan=2 class="tblHeader"><h3><?php echo _('Poser'); ?></h3></td></tr>
+<tr>
+    <td><b><?php echo _('Path to Poser'); ?></b>:</td>
+    <td><?php echo $form->textField('poserPath', ''); ?></td>
+</tr>
+<?php
+if (CoreLocal::get('poserPath')) {
+    $poser = CoreLocal::get('poserPath');
+    if (!is_dir($poser)) {
+        echo '<tr><td colspan="2"><em>Warning: poser path is invalid</td></tr>';
+    }
+}
+?>
 <!--
 <tr><td colspan=2 class="tblHeader">
 <h3>Various</h3>

--- a/pos/is4c-nf/lib/AutoLoader.php
+++ b/pos/is4c-nf/lib/AutoLoader.php
@@ -204,7 +204,10 @@ class AutoLoader
         });
         $poser = CoreLocal::get('poserPath');
         if ($poser) {
-            $map = Plugin::pluginMap($poser . 'lane_plugins/', $map);
+            $path = $poser . '/lane_plugins/';
+            if (is_dir($path)) {
+                $map = Plugin::pluginMap($path, $map);
+            }
         }
         if (isset(self::$classPaths[$baseClass])) {
             $path = realpath(dirname(__FILE__) . self::$classPaths[$baseClass]);

--- a/pos/is4c-nf/lib/AutoLoader.php
+++ b/pos/is4c-nf/lib/AutoLoader.php
@@ -67,6 +67,10 @@ class AutoLoader
                 $ourPath = __DIR__ . $sep . '..' . $sep . strtr(substr($name, 12), '\\', $sep) . '.php';
                 $map[$name] = $ourPath;
                 CoreLocal::set('ClassLookup', $map);
+            } elseif (strpos($name, 'Poser\\') === 0) {
+                $ourPath = CoreLocal::get('poserPath') . strtr(substr($name, 6), '\\', $sep) . '.php';
+                $map[$name] = $ourPath;
+                CoreLocal::set('ClassLookup', $map);
             }
         } elseif (!isset($map[$name])) {
             // class is unknown
@@ -198,6 +202,10 @@ class AutoLoader
         $map = array_filter(CoreLocal::get('ClassLookup'), function ($i) {
             return strpos($i, 'plugins') > 0;
         });
+        $poser = CoreLocal::get('poserPath');
+        if ($poser) {
+            $map = Plugin::pluginMap($poser . 'lane_plugins/', $map);
+        }
         if (isset(self::$classPaths[$baseClass])) {
             $path = realpath(dirname(__FILE__) . self::$classPaths[$baseClass]);
             $map = Plugin::pluginMap($path,$map);
@@ -266,11 +274,17 @@ class AutoLoader
         }
 
         $path = realpath(dirname(__FILE__) . '/../') . DIRECTORY_SEPARATOR;
+        $prefix = 'COREPOS\\pos';
+        $poser = CoreLocal::get('poserPath');
+        if ($poser && strpos($path, $poser) === 0) {
+            $path = $poser;
+            $prefix = 'Poser';
+        }
         $file = str_replace($path, '', $file);
         $nss = array_reduce(explode(DIRECTORY_SEPARATOR, $file),
             function ($carry, $item) { return $carry . '\\' . $item; });
 
-        return 'COREPOS\\pos' . $nss;
+        return $prefix . $nss;
     }
 
     /**


### PR DESCRIPTION
so far this only lets Fannie plugins exist in Poser

This is very basic, and I'm not suggesting it's ready for merge necessarily.  Just wanted to start exploring what this might look like.

I should also say, I'm not tied to the name "Poser" and happy to change that.  If so now is the time...

As discussed elsewhere, the idea here is just to allow a "customization layer" which can contain multiple plugins and other org-specific logic and assets required to allow the org to run upstream CORE at all times.

In a local test I have CORE upstream/master and also an example Poser project (code [here](https://kallithea.rattailproject.org/rattail-project/corepos-demo-poser)), which exposes one additional plugin.  To my `fannie/config.php` I defined the path to it:

```php
$FANNIE_POSER = '/srv/corepos/upstream/corepos-demo-poser';
```

Then when I visit `fannie/install/InstallPluginsPage.php` (with this PR change in effect) I see the plugin listed.

![Screenshot from 2021-06-22 14-08-06](https://user-images.githubusercontent.com/134969/122985024-4eab3c00-d363-11eb-913a-bcb75304eb6a.png)
