### PR TITLE
Skip triggers for mysqldump of `products` when syncing to lane

### DIFF
--- a/fannie/sync/special/products.multi.php
+++ b/fannie/sync/special/products.multi.php
@@ -60,6 +60,7 @@ $cmd = 'mysqldump'
     . ' -h ' . escapeshellarg($host)
     . ' -P ' . escapeshellarg($port)
     . ' -w ' . escapeshellarg('store_id=' . ((int)$FANNIE_STORE_ID))
+    . ' --skip-triggers '
     . ' ' . escapeshellarg($FANNIE_OP_DB)
     . ' ' . escapeshellarg($table)
     . ' > ' . escapeshellarg($tempfile)
@@ -70,6 +71,7 @@ $cmd_obfusc = 'mysqldump'
     . ' -h ' . escapeshellarg($host)
     . ' -P ' . escapeshellarg($port)
     . ' -w ' . escapeshellarg('store_id=' . ((int)$FANNIE_STORE_ID))
+    . ' --skip-triggers '
     . ' ' . escapeshellarg($FANNIE_OP_DB)
     . ' ' . escapeshellarg($table)
     . ' > ' . escapeshellarg($tempfile);


### PR DESCRIPTION
presumably no need to copy triggers to the lane, but they may be
present on the server.  in my experience the ownership was such that
installing them to lane would have required privilege escalation, but
i prefer to just skip them

This again is just my idea of how this should work.  Happy to tweak as needed to accommodate others.

My own setup has triggers on the server/office DB so that a Rattail app can more reliably know when things change.  Not sure if anyone else even has triggers but am guessing they would not need the same ones on lane at any rate?