### PR TITLE
Avoid empty case size when saving vendorItem in base module

### DIFF
--- a/fannie/item/modules/BaseItemModule.php
+++ b/fannie/item/modules/BaseItemModule.php
@@ -1162,6 +1162,14 @@ HTML;
                 $sku = $upc;
             }
 
+            /**
+             * Must have a valid value for the data type.
+             * The default in the Model is 1.
+             */
+            if (empty($caseSize)) {
+                $caseSize = 1;
+            }
+
             $chkP = $dbc->prepare("SELECT upc FROM vendorItems
                 WHERE sku=? AND vendorID=? AND upc <> ?");
             $chk = $dbc->getValue($chkP, array($sku, $vendorID, $upc));


### PR DESCRIPTION
when STRICT_TRANS_TABLES (i think) is in effect for sql mode, an empty
case size value will cause a warning and vendorItem is not saved.  so
we shouldn't try to use the empty value if user leaves that blank