### PR TITLE
Avoid empty string when writing shelf tags

### DIFF
--- a/fannie/item/addShelfTag.php
+++ b/fannie/item/addShelfTag.php
@@ -148,7 +148,11 @@ HTML;
           $shelftag->brand(FormLib::get('brand'));
           $shelftag->sku(FormLib::get('sku'));
           $shelftag->size(FormLib::get('size'));
-          $shelftag->units(FormLib::get('units'));
+          $units = FormLib::get('units');
+          if (empty($units)) {
+              $units = 1;
+          }
+          $shelftag->units($units);
           $shelftag->vendor(FormLib::get('vendor'));
           $shelftag->count(FormLib::get('count', 1));
           $insR = $shelftag->save();


### PR DESCRIPTION
similar problem as 4f759fd162019e8821d7a1f68bb9cbbf1f914621