### PR TITLE
Avoid TLS in local SMTP connection for ScheduledEmailSendTask

### DIFF
--- a/fannie/modules/plugins2.0/ScheduledEmails/ScheduledEmailSendTask.php
+++ b/fannie/modules/plugins2.0/ScheduledEmails/ScheduledEmailSendTask.php
@@ -128,6 +128,7 @@ class ScheduledEmailSendTask extends FannieTask
 
         $mail = OutgoingEmail::get();
         $mail->isSMTP();
+        $mail->SMTPAutoTLS = false;
         $mail->Host = '127.0.0.1';
         $mail->Port = 25;
         $mail->SMTPAuth = false;


### PR DESCRIPTION
Presumably local mail service does not require TLS, and probably has self-signed certificates anyway which would not work by default.

Perhaps this should be a setting somewhere though, in case local SMTP *should* require TLS?