### PR TITLE
Expose the LogEscalator plugin as a scheduled task

### DIFF
--- a/fannie/modules/plugins2.0/LogEscalator/LogEscalatorTask.php
+++ b/fannie/modules/plugins2.0/LogEscalator/LogEscalatorTask.php
@@ -7,6 +7,10 @@
  */
 class LogEscalatorTask extends FannieTask
 {
+    public $name = 'Log Escalator';
+
+    public $description = 'Send email notifications for logged errors & warnings.';
+
     public $default_schedule = array(
         'min' => '*/10',
         'hour' => '*',


### PR DESCRIPTION
Not sure if there was a reason to keep it hidden from scheduled tasks, or if this change breaks anything else..?  I'm pretty unfamiliar with the whole PHP class/namespace thing still.  But for me locally, this does make it show up in scheduled tasks.