### PR TITLE
Add `host_test_connect()` util function; refactor lane status checks

### DIFF
--- a/fannie/admin/LaneStatus.php
+++ b/fannie/admin/LaneStatus.php
@@ -76,6 +76,7 @@ class LaneStatus extends FannieRESTfulPage
     protected function get_view()
     {
         $status = '';
+        $timeout = 2;
         $i = 1;
         foreach ($this->config->get('LANES') as $lane) {
             if ($lane['offline']) {
@@ -85,7 +86,7 @@ class LaneStatus extends FannieRESTfulPage
             } else {
                 $css = 'danger';
                 $label = 'Down';
-                if (check_db_host($lane['host'], $lane['type'], $timeout=2)) {
+                if (check_db_host($lane['host'], $lane['type'], $timeout)) {
                     $label = 'Up';
                     $css = 'success';
                 }

--- a/fannie/admin/LaneStatus.php
+++ b/fannie/admin/LaneStatus.php
@@ -84,15 +84,8 @@ class LaneStatus extends FannieRESTfulPage
                     $i, $lane['host'], $i);
             } else {
                 $css = 'danger';
-                $port = 3306;
-                $host = $lane['host'];
-                if (strstr($host,":")) {
-                    list($host,$port) = explode(":",$host);
-                }
                 $label = 'Down';
-                $connected = stream_socket_client('tcp://' . $host . ':' . $port, $errno, $err, 2);
-                if ($connected) {
-                    fclose($connected);
+                if (check_db_host($lane['host'], $lane['type'], $timeout=2)) {
                     $label = 'Up';
                     $css = 'success';
                 }

--- a/fannie/cron/tasks/CheckLanesTask.php
+++ b/fannie/cron/tasks/CheckLanesTask.php
@@ -21,6 +21,10 @@
 
 *********************************************************************************/
 
+if (!function_exists('check_db_host')) {
+    include(dirname(__FILE__).'/../../install/util.php');
+}
+
 class CheckLanesTask extends FannieTask
 {
     public $name = "Check Lane Connections";
@@ -52,12 +56,7 @@ class CheckLanesTask extends FannieTask
 
             // assume lane is offline unless proven otherwise
             $online = false;
-            $dbc = new SQLManager($lane['host'],
-                                  $lane['type'],
-                                  $lane['op'],
-                                  $lane['user'],
-                                  $lane['pw']);
-            if ($dbc->isConnected()) {
+            if (check_db_host($lane['host'], $lane['type'], $timeout=2)) {
                 $online = true;
             }
 
@@ -91,7 +90,7 @@ class CheckLanesTask extends FannieTask
                     curl_exec($ch);
                     curl_close($ch);
 
-                    $this->cronMsg("Fannie status for lane $number should now be correct");
+                    $this->cronMsg("Fannie status for lane $number should now be $actualStatus");
                 }
             }
 

--- a/fannie/cron/tasks/CheckLanesTask.php
+++ b/fannie/cron/tasks/CheckLanesTask.php
@@ -46,6 +46,7 @@ class CheckLanesTask extends FannieTask
         $url = "http://{$this->config->get('HTTP_HOST')}{$this->config->get('URL')}admin/LaneStatus.php";
 
         // loop thru all defined lanes
+        $timeout = 2;
         $number = 1;
         foreach ($this->config->get('LANES') as $lane) {
             $this->cronMsg("testing lane $number ({$lane['host']}) ...");
@@ -56,7 +57,7 @@ class CheckLanesTask extends FannieTask
 
             // assume lane is offline unless proven otherwise
             $online = false;
-            if (check_db_host($lane['host'], $lane['type'], $timeout=2)) {
+            if (check_db_host($lane['host'], $lane['type'], $timeout)) {
                 $online = true;
             }
 

--- a/fannie/install/util.php
+++ b/fannie/install/util.php
@@ -82,7 +82,7 @@ function confset($key, $value)
   @param $dbms [string] database software identifier
   @return [boolean]
 */
-function check_db_host($host,$dbms)
+function check_db_host($host,$dbms,$timeout=1)
 {
     if (!function_exists("socket_create")) {
         return true; // test not possible
@@ -115,7 +115,7 @@ function check_db_host($host,$dbms)
 
     $test = false;
     $sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-    socket_set_option($sock, SOL_SOCKET, SO_SNDTIMEO, array('sec' => 1, 'usec' => 0)); 
+    socket_set_option($sock, SOL_SOCKET, SO_SNDTIMEO, array('sec' => $timeout, 'usec' => 0));
     socket_set_block($sock);
     try {
         $test = @socket_connect($sock,$host,$port);


### PR DESCRIPTION
this is really for sake of CheckLanesTask, which didn't properly
handle the scenario of lane being currently offline.  but wanted to
share the logic between that and the `admin/LaneStatus.php` page.

This follows from #1080.