### PR TITLE
Allow null birthdate when editing cashier

### DIFF
--- a/fannie/admin/Cashiers/CashierEditor.php
+++ b/fannie/admin/Cashiers/CashierEditor.php
@@ -69,7 +69,11 @@ class CashierEditor extends FannieRESTfulPage
                 $employee->backendsecurity($this->form->fes);
                 $active = $this->form->tryGet('active', '') !== '' ? 1 : 0;
                 $employee->EmpActive($active);
-                $employee->birthdate($this->form->birthdate);
+                if ($this->form->birthdate) {
+                    $employee->birthdate($this->form->birthdate);
+                } else {
+                    $employee->birthdate(null);
+                }
                 $saved = $employee->save();
 
                 $this->saveStoreMapping($dbc, $emp_no);


### PR DESCRIPTION
Not sure if there are other edge cases, but this one seems to come up in the wild.  User blanks-out the birthdate field and then gets an error saving.