### PR TITLE
Detect missing item within batch history

### DIFF
--- a/fannie/batches/batchhistory/BatchHistoryPage.php
+++ b/fannie/batches/batchhistory/BatchHistoryPage.php
@@ -253,7 +253,11 @@ HTML;
                     $ret .= '<td>' . $obj->$upcCol() . '</td>';
                 }
                 $p = $dbc->getRow($prodP, array($obj->upc()));
-                $ret .= '<td><strong>'.$p['brand'].'</strong> '.$p['description'].'</td>';
+                if ($p === false) {
+                    $ret .= '<td>(ITEM NOT FOUND)</td>';
+                } else {
+                    $ret .= '<td><strong>'.$p['brand'].'</strong> '.$p['description'].'</td>';
+                }
             }
             $ret .= '</tr>';
         }


### PR DESCRIPTION
when the batch history table is rendered, but one of the items
contained in the batch no longer exists, fail gracefully

Not sure how often this comes up in practice but did see it in the wild.  It also seems like the warning, which brought it to my attention, only happens as of PHP 7.4, if that matters.

```
[2021-09-13 12:28:09] fannie.WARNING: Trying to access array offset on value of type bool Line 256, /srv/IS4C/fannie/batches/batchhistory/BatchHistoryPage.php [] []
```