### PR TITLE
Add setting for remote dir when uploading to SPINS

### DIFF
--- a/fannie/modules/plugins2.0/SPINS/SPINS.php
+++ b/fannie/modules/plugins2.0/SPINS/SPINS.php
@@ -35,6 +35,8 @@ class SPINS extends \COREPOS\Fannie\API\FanniePlugin
             'description'=>'ftp.spins.com credentials'), 
     'SpinsFtpPw' => array('default'=>'', 'label'=>'FTP Password',
             'description'=>'ftp.spins.com credentials'), 
+    'SpinsFtpDir' => array('default'=>'data', 'label'=>'FTP Directory',
+            'description'=>'Remote folder into which file should be uploaded.'),
     'SpinsOffset' => array('default'=>0, 'label'=>'Week Offset',
             'description'=>'SPINS often uses non-standard week numbering. The offset
             should be the difference between an ISO week number and the SPINS week

--- a/fannie/modules/plugins2.0/SPINS/SpinsSubmitTask.php
+++ b/fannie/modules/plugins2.0/SPINS/SpinsSubmitTask.php
@@ -119,7 +119,10 @@ class SpinsSubmitTask extends FannieTask
             if (!$conn_id || !$login_id) {
                 $this->cronMsg('FTP Connection failed', FannieLogger::ERROR);
             } else {
-                ftp_chdir($conn_id, "data");
+                $remoteDir = $FANNIE_PLUGIN_SETTINGS['SpinsFtpDir'];
+                if ($remoteDir) {
+                    ftp_chdir($conn_id, $remoteDir);
+                }
                 ftp_pasv($conn_id, true);
                 $uploaded = ftp_put($conn_id, $filename, $outfile, FTP_ASCII);
                 if (!$uploaded) {


### PR DESCRIPTION
sometimes the ftp connection can't chdir to 'data' folder.  upload
still seems to work, but this should let us avoid the chdir warning

Am wondering if 'data' should be the default setting value, or just empty string?