### PR TITLE
Refactor logic used for updating lane status

### DIFF
--- a/fannie/install/util.php
+++ b/fannie/install/util.php
@@ -75,6 +75,26 @@ function confset($key, $value)
     fclose($fptr);
 }
 
+// update the LANES setting in the config file
+function update_lanes($lanes)
+{
+    $saveStr = 'array(';
+    foreach ($lanes as $lane) {
+        $saveStr .= "array('host'=>'{$lane['host']}',"
+                 . "'type'=>'{$lane['type']}',"
+                 . "'user'=>'{$lane['user']}',"
+                 . "'pw'=>'{$lane['pw']}',"
+                 . "'op'=>'{$lane['op']}',"
+                 . "'trans'=>'{$lane['trans']}',"
+                 . "'offline'=>{$lane['offline']}),";
+    }
+    if ($saveStr != 'array(') {
+        $saveStr = substr($saveStr, 0, strlen($saveStr)-1);
+    }
+    $saveStr .= ')';
+    confset('FANNIE_LANES', $saveStr);
+}
+
 /**
   Briefly connect to host to verify it's accepting
   network connections


### PR DESCRIPTION
this consolidates the logic used to write LANES setting to Fannie
config file.  also the CheckLanesTask can now use this logic instead
of invoking a HTTP request

This is yet another take on #1080.

Hit a snag with how Fannie config may be used to build a URL for use with POSTing new lane status.  And since we already knew the approach wouldn't work if Fannie auth was enabled, I figure this is better?
