### PR TITLE
Avoid a "missing key" warning for Tags4x8P

### DIFF
--- a/fannie/classlib2.0/item/signage/Tags4x8P.php
+++ b/fannie/classlib2.0/item/signage/Tags4x8P.php
@@ -71,7 +71,11 @@ class Tags4x8P extends \COREPOS\Fannie\API\item\FannieSignage
             $pak = $item['units'];
             $size = $item['units'] . "-" . $item['size'];
             $sku = $item['sku'];
-            $ppu = $item['pricePerUnit'];
+            if (array_key_exists('pricePerUnit', $item)) {
+                $ppu = $item['pricePerUnit'];
+            } else {
+                $ppu = '';
+            }
             $vendor = substr($item['vendor'],0,7);
             if ($this->noDates) {
                 $vendor = $item['vendor'];


### PR DESCRIPTION
Just randomly encountered a warning for this while playing around...assuming this fix is sufficient.