### PR TITLE
Fix missing variable when trying to delete from ProductListPage

### DIFF
--- a/fannie/item/ProductListPage.php
+++ b/fannie/item/ProductListPage.php
@@ -241,7 +241,7 @@ class ProductListPage extends \COREPOS\Fannie\API\FannieReportTool
         return array(
             'alertBox'=>$ret,
             'upc'=>ltrim($upc, '0'),
-            'enc_desc'=>$encoded_desc
+            'enc_desc'=>base64_encode($desc),
         );
     }
 


### PR DESCRIPTION
Saw this one come up in the wild.  When viewing the ProductListPage, and trying to delete an item, it wouldn't work b/c of missing variable error.  This "fixes" although not clear to me that the value in question is actually used anywhere..

Also not entirely clear that it should be quite that easy to delete an item..!  But assuming the convenience is a good thing for power users etc.

Anyway this does fix the warning I saw which was:

```
[2021-09-30 13:10:14] fannie.WARNING: Undefined variable: encoded_desc Line 244, /srv/corepos/upstream/fannie/IS4C/fannie/item/ProductListPage.php [] []
```