### PR TITLE
Allow plugins to be symlinks

### DIFF
--- a/common/CorePlugin.php
+++ b/common/CorePlugin.php
@@ -86,8 +86,22 @@ class CorePlugin
     */
     public static function memberOf($file, $exclude='plugins')
     {
-        $file = realpath($file);
         $sep = DIRECTORY_SEPARATOR;
+
+        // nb. if parent folder of this file is a symlink, then
+        // realpath() will *resolve* that and return the "true" path
+        // for the file on disk.  but we want to allow symlinks to
+        // exist and for plugins within them to be treated as "native"
+        // so to accomplish that we use the following workaround.
+        $info = pathinfo($file);
+        if (is_link($info['dirname'])) {
+            $parent = pathinfo($info['dirname']);
+            $file = realpath($parent['dirname']) . $sep
+                  . $parent['basename'] . $sep
+                  . $info['basename'];
+        } else {
+            $file = realpath($file);
+        }
 
         $dirs = explode($sep, $file);
         for($i=0;$i<count($dirs);$i++) {


### PR DESCRIPTION
for my local dev i have GitStatus plugin symlinked into the "normal"
location at `fannie/modules/plugins2.0/GitStatus` - i.e. instead of
installing it via Composer, which of course would work but then my
`composer.lock` file would be out of whack with upstream.

the plugin itself worked okay i think but did not appear on the
Scheduled Tasks page.  so with this tweak it *does* appear.

Not sure if there are any other implications, esp. since this change affects more than Office...  Maybe also you have a different / better idea for how I can get what I want?