### PR TITLE
Honor the "Never email on error" option for Task Error Severity

### DIFF
--- a/fannie/classlib2.0/FannieTask.php
+++ b/fannie/classlib2.0/FannieTask.php
@@ -139,8 +139,11 @@ class FannieTask
         $this->logger->log($log_level, $info->getName() . ': ' . $str); 
 
         // raise message into stderr
-        if ($severity <= $this->error_threshold) {
-            file_put_contents('php://stderr', $msg, FILE_APPEND);
+        // nb. 99 means "Never email on error"
+        if ($this->error_threshold != 99) {
+            if ($severity <= $this->error_threshold) {
+                file_put_contents('php://stderr', $msg, FILE_APPEND);
+            }
         }
 
         return '';


### PR DESCRIPTION
maybe that option should be -1 instead of 99?  but this works too