### PR TITLE
Write creds to file instead of passing on cmd line, for mysqldump

### DIFF
--- a/fannie/modules/plugins2.0/SimpleBackup/SimpleBackupTask.php
+++ b/fannie/modules/plugins2.0/SimpleBackup/SimpleBackupTask.php
@@ -83,7 +83,8 @@ class SimpleBackupTask extends FannieTask
 [mysqldump]
 user = {$FANNIE_SERVER_USER}
 password = {$FANNIE_SERVER_PW}
-EOF);
+EOF
+            );
             fclose($fh);
 
             $cmd = escapeshellcmd($cmd);


### PR DESCRIPTION
This is just to avoid a warning from `mysqldump` when passing credentials on command line.  Which can lead to email every night..