### PR TITLE
Allow null cost value when creating new product

### DIFF
--- a/fannie/item/modules/BaseItemModule.php
+++ b/fannie/item/modules/BaseItemModule.php
@@ -987,7 +987,7 @@ HTML;
                 $model->normal_price($price[$i]);
             }
             $cost = $this->formNoEx('cost', array());
-            if (isset($cost[$i])) {
+            if (isset($cost[$i]) && $cost[$i] != '') {
                 $model->cost($cost[$i]);
             }
             $desc = $this->formNoEx('descript', array());


### PR DESCRIPTION
if user blanks-out the cost field when making new product, the cost
value comes through as empty string, which is not valid per data type

This is pretty minor and you may have other ideas on how (or if) it should be handled.  But have seen this warning in the wild lately.