### PR TITLE
Add `preprocess()` logic for `InstallPluginsPage.php`

### DIFF
--- a/fannie/classlib2.0/FanniePlugin.php
+++ b/fannie/classlib2.0/FanniePlugin.php
@@ -148,12 +148,14 @@ class FanniePlugin extends \COREPOS\common\CorePlugin
     private function getFromConfig()
     {
         $config = \FannieConfig::factory();
+        $allSettings = $config->get('PLUGIN_SETTINGS');
         $ret = array();
-        foreach ($this->plugin_settings as $key => $definition) {
+        foreach ($this->plugin_settings as $name => $definition) {
+            $key = $name;
             if (strlen($this->settingsNamespace) > 0) {
                 $key = $this->settingsNamespace . '.' . $key;
             }
-            $ret[$key] = $config->get($key);
+            $ret[$name] = isset($allSettings[$key]) ? $allSettings[$key] : '';
         }
 
         return $ret;


### PR DESCRIPTION
- cleanup logic so easier to read/maintain
- make sure settings are only saved upon form POST

this also tweaks how plugin settings are retrieved from config file
generally, to better handle namespace if present

This of course should be vetted thoroughly..  I believe the only behavioral change should be how a v1 plugin settings are got from config file, as mentioned above.  And, settings are no longer saved just by visiting the page.

My end goal here is to make sure DB settings are "overwritten" but I want to avoid truncating that table, so as to allow "ad-hoc" settings to be added, and this page should not touch them if present.

Anyway wanted to make sure this was an okay direction first etc.  Let me know what you think.