### PR TITLE
Add fallback for `SCRIPT_FILENAME`, in `AjaxCallback` on FastCGI

### DIFF
--- a/pos/is4c-nf/lib/AjaxCallback.php
+++ b/pos/is4c-nf/lib/AjaxCallback.php
@@ -65,6 +65,9 @@ class AjaxCallback
         register_shutdown_function(array('COREPOS\\pos\\lib\\AjaxCallback', 'ajaxFatal'));
         $callback_class = get_called_class();
         $file = filter_input(INPUT_SERVER, 'SCRIPT_FILENAME');
+        // nb. if FastCGI is in use, the above may return null, in
+        // which case we must provide a fallback
+        if (!$file) $file = $_SERVER['SCRIPT_FILENAME'];
         $nsClass = AutoLoader::fileToFullClass($file);
         self::$logger = new LaneLogger();
         if ($callback_class === $nsClass || basename($file) === $callback_class . '.php') {


### PR DESCRIPTION
There seems to be a problem with the `AjaxCallback` mechanism when FastCGI is in use?

In practice what we saw was, when logged into the POS lane as cashier, entering "anything" into the main input box, it was ignored and nothing would happen.  The front-end was submitting entry to the web server, but the response was totally empty.

Finally figured out that the server wasn't able to determine the `SCRIPT_FILENAME` value using current code.  After some searching I found [this](https://stackoverflow.com/a/36205923) which mentioned FastCGI, and then I confirmed that we *are* using FastCGI for the install where this bug was seen.

So this commit "fixes" for the install in question, but I'm not sure what the implications are of merging it..?  Seems safe enough to me but you may have better ideas.