### PR TITLE
Avoid writing empty string to integer field, for `products.quantity`

### DIFF
--- a/fannie/item/modules/VolumePricingModule.php
+++ b/fannie/item/modules/VolumePricingModule.php
@@ -82,6 +82,9 @@ class VolumePricingModule extends \COREPOS\Fannie\API\item\ItemModule
 
         $method = FormLib::get_form_value('vp_method',0);
         $qty = FormLib::get_form_value('vp_qty',0);
+        if ($qty === '') {      // not a valid integer
+            $qty = null;
+        }
         $price = FormLib::get_form_value('vp_price',0);
         $mixmatch = FormLib::get_form_value('vp_mm',0);
 


### PR DESCRIPTION
Small tweak to cut down on warnings.