### PR TITLE
Use unique hidden token field for each form on page

### DIFF
--- a/fannie/src/javascript/core.js
+++ b/fannie/src/javascript/core.js
@@ -284,11 +284,12 @@ function chainSubDepartments(ws_url, params)
 
 function appendTokens(token) {
     var forms = document.forms;
-    var field = document.createElement('input');
-    field.type = 'hidden';
-    field.name = '_token_';
-    field.value = token;
+    var field;
     for (var i=0; i<forms.length; i++) {
+        field = document.createElement('input');
+        field.type = 'hidden';
+        field.name = '_token_';
+        field.value = token;
         forms[i].appendChild(field);
     }
 }


### PR DESCRIPTION
don't insert same element on multiple forms

Stumbled across this problem by accident but I think it may be worth fixing?  With `fannie/batches/newbatch/EditBatchPage.php` displayed in browser, there were 3 forms on page but the one for adding an item to batch did *not* have a token field.  That particular form uses GET anyway, so no CSRF token technically needed I think.

But this code change did seem to fix the issue anyhow; token field was added to all 3 forms okay.