### PR TITLE
Add another `filter_input()` fallback for FastCGI

### DIFF
--- a/fannie/classlib2.0/FannieRESTfulPage.php
+++ b/fannie/classlib2.0/FannieRESTfulPage.php
@@ -132,7 +132,12 @@ class FannieRESTfulPage extends FanniePage
         } catch (Exception $ex) {
             $this->__method = filter_input(INPUT_SERVER, 'REQUEST_METHOD');
             if ($this->__method === null) {
-                $this->__method = 'get';
+                // fallback in case FastCGI is in use
+                $this->__method = $_SERVER['REQUEST_METHOD'];
+                if ($this->__method === null) {
+                    // generic fallback
+                    $this->__method = 'get';
+                }
             }
         }
         $this->__method = strtolower($this->__method);


### PR DESCRIPTION
this fixes fairly major REST routing bugs with FastCGI

see also https://github.com/CORE-POS/IS4C/pull/1154

Grep tells me there are ~130 instances of the string `filter_input(INPUT_SERVER` just in the `fannie/` subdir alone.

Not sure these are all worth fixing, vs. should just declare FastCGI "not supported" - but this one is fairly low-hanging fruit which can affect lots of the app, so figured might as well.