### PR TITLE
Remove `maknz/slack` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "ramsey/uuid": "^3.6",
         "aws/aws-sdk-php": "^3.31",
         "corepos/class-cache": "^1.1",
-        "maknz/slack": "^1.7",
         "smalot/pdfparser": "^0.11.0",
         "spomky-labs/otphp": "^8.0",
         "drewm/mailchimp-api": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a18dd79c05262b333c50ee48e6edeebd",
+    "content-hash": "e9bf8e372a30a1a52dfba92c74159544",
     "packages": [
         {
             "name": "automattic/woocommerce",
@@ -1728,55 +1728,6 @@
             ],
             "abandoned": "mailchimp/marketing",
             "time": "2014-10-30T20:38:12+00:00"
-        },
-        {
-            "name": "maknz/slack",
-            "version": "1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/maknz/slack.git",
-                "reference": "7f21fefc70c76b304adc1b3a780c8740dfcfb595"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/maknz/slack/zipball/7f21fefc70c76b304adc1b3a780c8740dfcfb595",
-                "reference": "7f21fefc70c76b304adc1b3a780c8740dfcfb595",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "0.9.*",
-                "phpunit/phpunit": "4.2.*"
-            },
-            "suggest": {
-                "illuminate/support": "Required for Laravel support"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Maknz\\Slack\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "maknz",
-                    "email": "github@mak.geek.nz"
-                }
-            ],
-            "description": "A simple PHP package for sending messages to Slack, with a focus on ease of use and elegant syntax. Includes Laravel support out of the box.",
-            "keywords": [
-                "laravel",
-                "slack"
-            ],
-            "time": "2015-06-03T03:35:16+00:00"
         },
         {
             "name": "markbaker/complex",


### PR DESCRIPTION
must install separately if needed

It's not a show-stopper for me if this needs to stay in, but kinda seemed like it could come out.  In practice it's keeping us with older `guzzlehttp/guzzle` - which I discovered in #1185.  The [maknz/slack](https://packagist.org/packages/maknz/slack) lib (1.7.0) requires guzzle 0.6 but latest is 0.7 - I worked around by supporting either in [rattail/posterior](https://packagist.org/packages/rattail/posterior).

The slack requirement was added in https://github.com/CORE-POS/IS4C/commit/52220f112528e30c3aa127f72e55d7b480a1017f but IIUC this would only come up if someone used the IncidentTracker plugin?