### PR TITLE
description and brand length in BaseItemModule

### DIFF
--- a/fannie/item/modules/BaseItemModule.php
+++ b/fannie/item/modules/BaseItemModule.php
@@ -1014,10 +1014,12 @@ HTML;
             }
             $desc = $this->formNoEx('descript', array());
             if (isset($desc[$i])) {
+                $desc[$i] = substr($desc[$i],0,30);
                 $model->description(strtoupper($desc[$i]));
             }
             $brand = $this->formNoEx('manufacturer', array());
             if (isset($brand[$i])) {
+                $brand[$i] = substr($brand[$i],0,30);
                 $model->brand(strtoupper($brand[$i]));
             }
             /**


### PR DESCRIPTION
These changes reduce the lengths of `description` and `brand` so the UPDATEs of `products` will not fail.  Values imported from `vendorItems` can be longer than `products` supports.