### PR TITLE
Allow API access to TRANS_DB

### DIFF
--- a/fannie/classlib2.0/webservices/FannieEntity.php
+++ b/fannie/classlib2.0/webservices/FannieEntity.php
@@ -120,7 +120,12 @@ class FannieEntity extends FannieWebService
          * Make sure all provided columns are valid
          */
         $model = $args->entity . 'Model';
-        $obj = new $model(FannieDB::get(FannieConfig::config('OP_DB')));
+        $dbc = FannieDB::get(FannieConfig::config('OP_DB'));
+        $obj = new $model($dbc);
+        if ($obj->preferredDB() == 'trans') {
+            $dbc = FannieDB::get(FannieConfig::config('TRANS_DB'));
+            $obj = new $model($dbc);
+        }
         $cols = $obj->getColumns();
         foreach ($args->columns as $key => $val) {
             if (!isset($cols[$key])) {


### PR DESCRIPTION
for models declaring that preference, e.g. Stockpurchases

Having to sync equity payments between two systems and first step is just to read them from CORE.  I believe this is a sane change but not real sure of any implications beyond the obvious, i.e. it does grant access to "trans" DB, which is the intent.  But there may be security/performance or other concerns I'm not aware of yet.