### PR TITLE
Add dedicated webservice endpoint for `FannieEquity`

### DIFF
--- a/fannie/classlib2.0/webservices/FannieEquity.php
+++ b/fannie/classlib2.0/webservices/FannieEquity.php
@@ -140,9 +140,12 @@ class FannieEquity extends FannieWebService
             'emp_no' => $empNo,
         ];
 
+        $dbc->startTransaction();
+
         // open ring for equity
         $params = (array)$common;
         if (!DTrans::addOpenRing($dbc, $deptNo, $total, $transNo, $params)) {
+            $dbc->rollbackTransaction();
             $ret['error'] = [
                 'code' => -32000, // TODO: what should this be?
                 'message' => 'Failed to insert open ring item',
@@ -157,6 +160,7 @@ class FannieEquity extends FannieWebService
         $params['trans_subtype'] = $tenderCode;
         $params['total'] = $total * -1;
         if (!DTrans::addItem($dbc, $transNo, $params)) {
+            $dbc->rollbackTransaction();
             $ret['error'] = [
                 'code' => -32000, // TODO: what should this be?
                 'message' => 'Failed to insert tender item',
@@ -171,6 +175,7 @@ class FannieEquity extends FannieWebService
             $params['trans_type'] = 'C';
             $params['trans_subtype'] = 'CM';
             if (!DTrans::addItem($dbc, $transNo, $params)) {
+                $dbc->rollbackTransaction();
                 $ret['error'] = [
                     'code' => -32000, // TODO: what should this be?
                     'message' => 'Failed to insert comment item',
@@ -178,6 +183,8 @@ class FannieEquity extends FannieWebService
                 return $ret;
             }
         }
+
+        $dbc->commitTransaction();
 
         $result = (array)$common;
         $result['trans_no'] = $transNo;

--- a/fannie/classlib2.0/webservices/FannieEquity.php
+++ b/fannie/classlib2.0/webservices/FannieEquity.php
@@ -21,7 +21,7 @@ class FannieEquity extends FannieWebService
 
         if ($submethod != 'add_equity') {
             $ret['error'] = [
-                'code' => -32000, // TODO: what should this be?
+                'code' => 1,
                 'message' => 'only add_equity submethod is supported',
             ];
             return $ret;
@@ -43,7 +43,7 @@ class FannieEquity extends FannieWebService
         $cardNo = $args->columns->card_no;
         if (!isset($cardNo)) {
             $ret['error'] = [
-                'code' => -32000, // TODO: what should this be?
+                'code' => 1,
                 'message' => 'card_no column is required',
             ];
             return $ret;
@@ -53,7 +53,7 @@ class FannieEquity extends FannieWebService
         $total = $args->columns->total;
         if (!isset($total)) {
             $ret['error'] = [
-                'code' => -32000, // TODO: what should this be?
+                'code' => 1,
                 'message' => 'total column is required',
             ];
             return $ret;
@@ -63,7 +63,7 @@ class FannieEquity extends FannieWebService
         $deptNo = $args->columns->department;
         if (!isset($deptNo)) {
             $ret['error'] = [
-                'code' => -32000, // TODO: what should this be?
+                'code' => 1,
                 'message' => 'department column is required',
             ];
             return $ret;
@@ -73,7 +73,7 @@ class FannieEquity extends FannieWebService
         $result = preg_match_all("/[0-9]+/", $config->get('EQUITY_DEPARTMENTS'), $equityDepartments);
         if ($result == 0){
             $ret['error'] = [
-                'code' => -32000, // TODO: what should this be?
+                'code' => 1,
                 'message' => 'cannot read list of equity departments from config',
             ];
             return $ret;
@@ -83,7 +83,7 @@ class FannieEquity extends FannieWebService
         // validate requested department
         if (!in_array($deptNo, $equityDepartments)) {
             $ret['error'] = [
-                'code' => -32000, // TODO: what should this be?
+                'code' => 1,
                 'message' => "department $deptNo cannot be used for equity",
             ];
             return $ret;
@@ -93,7 +93,7 @@ class FannieEquity extends FannieWebService
         $tenderCode = $args->columns->tender;
         if (!isset($tenderCode)) {
             $ret['error'] = [
-                'code' => -32000, // TODO: what should this be?
+                'code' => 1,
                 'message' => 'tender column is required',
             ];
             return $ret;
@@ -111,7 +111,7 @@ class FannieEquity extends FannieWebService
         // validate requested tender
         if (!isset($tenders[$tenderCode])) {
             $ret['error'] = [
-                'code' => -32000, // TODO: what should this be?
+                'code' => 1,
                 'message' => 'speficied tender is not valid',
             ];
             return $ret;
@@ -147,7 +147,7 @@ class FannieEquity extends FannieWebService
         if (!DTrans::addOpenRing($dbc, $deptNo, $total, $transNo, $params)) {
             $dbc->rollbackTransaction();
             $ret['error'] = [
-                'code' => -32000, // TODO: what should this be?
+                'code' => 2,
                 'message' => 'Failed to insert open ring item',
             ];
             return $ret;
@@ -162,7 +162,7 @@ class FannieEquity extends FannieWebService
         if (!DTrans::addItem($dbc, $transNo, $params)) {
             $dbc->rollbackTransaction();
             $ret['error'] = [
-                'code' => -32000, // TODO: what should this be?
+                'code' => 2,
                 'message' => 'Failed to insert tender item',
             ];
             return $ret;
@@ -177,7 +177,7 @@ class FannieEquity extends FannieWebService
             if (!DTrans::addItem($dbc, $transNo, $params)) {
                 $dbc->rollbackTransaction();
                 $ret['error'] = [
-                    'code' => -32000, // TODO: what should this be?
+                    'code' => 2,
                     'message' => 'Failed to insert comment item',
                 ];
                 return $ret;


### PR DESCRIPTION
for sake of adding proper equity transactions

Well despite what I said in https://github.com/CORE-POS/IS4C/pull/1189#issuecomment-1704482742 once I dug in it seemed like the final insertion logic really belonged in CORE.  Since it auto-determines next `trans_no` and who knows what else.

So here is a first attempt at ``add_equity`` API method (based on concepts from [MemEquityTransferTool](https://github.com/CORE-POS/IS4C/blob/master/fannie/mem/correction_pages/MemEquityTransferTool.php)).  It doesn't do extensive input validation yet, and notably, it only adds 1 record to `dtransactions` - so it "rings up" the equity but doesn't pay for it, I guess.

In local testing, this much was sufficient for CORE to process these records as equity history, per usual AFAIK.  I haven't looked at any reports yet so not sure how those might be affected.  Must we add a tender record as well?  Or is that just up to the bookkeeper, whether they need it shown on reports?

I feel like I still don't know what I don't know, to really get this "right" all the way around.  Also not clear on the employee and register numbers, can I pass in something "made up" or must these be valid?

So am wondering if you think this new API endpoint is a good approach, and if so what it lacks.  I don't mind coding but am not sure what it needs from a "native" perspective.