### PR TITLE
avoid triggers for `mysqldump` during lane sync

### DIFF
--- a/fannie/sync/special/generic.mysql.php
+++ b/fannie/sync/special/generic.mysql.php
@@ -59,6 +59,7 @@ $cmd = 'mysqldump'
     . (empty($FANNIE_SERVER_PW) ? '' : ' -p' . escapeshellarg($FANNIE_SERVER_PW))
     . ' -h ' . escapeshellarg($host)
     . ' -P ' . escapeshellarg($port)
+    . ' --skip-triggers'
     . ' ' . escapeshellarg($FANNIE_OP_DB)
     . ' ' . escapeshellarg($table)
     . ' > ' . escapeshellarg($tempfile)
@@ -68,6 +69,7 @@ $cmd_obfusc = 'mysqldump'
     . ' -p' . str_repeat('*', 8)
     . ' -h ' . escapeshellarg($host)
     . ' -P ' . escapeshellarg($port)
+    . ' --skip-triggers'
     . ' ' . escapeshellarg($FANNIE_OP_DB)
     . ' ' . escapeshellarg($table)
     . ' > ' . escapeshellarg($tempfile);


### PR DESCRIPTION
i have some triggers in my Office 'op' DB but sync was adding them to the lane DB, in a broken state which caused further problems.

whether or not triggers should be included, could be configurable if needed but my guess is nobody else *needs* triggers included?